### PR TITLE
fix: handle non-square resolutions in generate_masks

### DIFF
--- a/freefuse_comfyui/__init__.py
+++ b/freefuse_comfyui/__init__.py
@@ -32,6 +32,7 @@ from .nodes import (
     # Mask application
     FreeFuseMaskApplicator,
     FreeFuseMaskDebug,
+    FreeFuseMaskBankFromImages,
     FreeFuseMaskTap,
     FreeFuseMaskReassemble,
     # Preview

--- a/freefuse_comfyui/freefuse_core/mask_utils.py
+++ b/freefuse_comfyui/freefuse_core/mask_utils.py
@@ -321,25 +321,44 @@ def generate_masks(
         N = first_map.shape[1]
         
         # Use provided latent dimensions if available (CRITICAL for non-square!)
+        # N may include extra non-spatial tokens (register/class tokens) beyond h*w
+        extra_tokens = 0
         if latent_h is not None and latent_w is not None:
             h, w = latent_h, latent_w
             if h * w != N:
-                # Similarity maps might be from a different resolution (e.g., packed Flux)
-                # Try to find compatible factors
+                # Try exact match at different downsampling scales
+                found = False
                 for scale in [1, 2, 4, 8]:
                     test_h, test_w = latent_h // scale, latent_w // scale
                     if test_h * test_w == N:
                         h, w = test_h, test_w
+                        found = True
                         break
-                else:
-                    print(f"[generate_masks] Warning: latent {latent_h}x{latent_w} ({latent_h*latent_w}) != N ({N})")
-                    # Fallback to square assumption
-                    h = w = int(N ** 0.5)
+
+                if not found:
+                    # Try approximate match: find scale where spatial < N
+                    # Extra tokens (register/class tokens) will be stripped
+                    best_h, best_w, best_extra = None, None, N + 1
+                    for scale in [1, 2, 4, 8]:
+                        test_h, test_w = latent_h // scale, latent_w // scale
+                        spatial = test_h * test_w
+                        extra = N - spatial
+                        if 0 < extra < best_extra and extra < spatial * 0.05:
+                            best_h, best_w, best_extra = test_h, test_w, extra
+
+                    if best_h is not None:
+                        h, w = best_h, best_w
+                        extra_tokens = best_extra
+                        print(f"[generate_masks] Detected {extra_tokens} non-spatial tokens "
+                              f"(N={N}, spatial={h}x{w}={h*w}), stripping before reshape")
+                    else:
+                        print(f"[generate_masks] Warning: latent {latent_h}x{latent_w} "
+                              f"({latent_h*latent_w}) != N ({N}), falling back to square")
+                        h = w = int(N ** 0.5)
         else:
             # No latent dims provided - try square first, then find factors
             h = w = int(N ** 0.5)
             if h * w != N:
-                # Try to find factors (prefer wider aspect for landscape, taller for portrait)
                 # WARNING: This is a fallback and may produce incorrect results!
                 print(f"[generate_masks] WARNING: No latent dimensions provided for non-square N={N}!")
                 for i in range(int(N ** 0.5), 0, -1):
@@ -347,15 +366,20 @@ def generate_masks(
                         h = i
                         w = N // i
                         break
-        
+
+        spatial_n = h * w
         if debug:
-            print(f"[generate_masks] Converting (B={B}, N={N}, 1) to spatial ({h}, {w})")
-        
+            msg = f"[generate_masks] Converting (B={B}, N={N}, 1) to spatial ({h}, {w})"
+            if extra_tokens > 0:
+                msg += f" [stripping {extra_tokens} extra tokens]"
+            print(msg)
+
         maps_spatial = []
         for m in maps:
             if m.dim() == 3:
                 m = m.squeeze(-1)  # (B, N)
-            spatial = m[0].view(h, w)  # Take first batch, reshape to spatial
+            # Strip extra non-spatial tokens (register/class tokens) before reshape
+            spatial = m[0][:spatial_n].view(h, w)
             maps_spatial.append(spatial)
         maps = maps_spatial
         target_shape = (h, w)

--- a/freefuse_comfyui/nodes/__init__.py
+++ b/freefuse_comfyui/nodes/__init__.py
@@ -37,6 +37,7 @@ from .attention_bias import (
     NODE_DISPLAY_NAME_MAPPINGS as ATTN_BIAS_DISPLAY_MAPPINGS,
 )
 from .mask_tap import (
+    FreeFuseMaskBankFromImages,
     FreeFuseMaskTap,
     FreeFuseMaskReassemble,
 )
@@ -52,6 +53,7 @@ NODE_CLASS_MAPPINGS = {
     "FreeFuseMaskPreview": FreeFuseMaskPreview,
     "FreeFuseMaskApplicator": FreeFuseMaskApplicator,
     "FreeFuseMaskDebug": FreeFuseMaskDebug,
+    "FreeFuseMaskBankFromImages": FreeFuseMaskBankFromImages,
     "FreeFuseMaskTap": FreeFuseMaskTap,
     "FreeFuseMaskReassemble": FreeFuseMaskReassemble,
     # Attention bias nodes
@@ -69,6 +71,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "FreeFuseMaskPreview": "FreeFuse Mask Preview",
     "FreeFuseMaskApplicator": "FreeFuse Mask Applicator",
     "FreeFuseMaskDebug": "FreeFuse Mask Debug",
+    "FreeFuseMaskBankFromImages": "FreeFuse Mask Bank From Images",
     "FreeFuseMaskTap": "FreeFuse Mask Tap",
     "FreeFuseMaskReassemble": "FreeFuse Mask Reassemble",
     # Attention bias nodes
@@ -89,6 +92,7 @@ __all__ = [
     # Mask application
     "FreeFuseMaskApplicator",
     "FreeFuseMaskDebug",
+    "FreeFuseMaskBankFromImages",
     "FreeFuseMaskTap",
     "FreeFuseMaskReassemble",
     # Attention bias

--- a/freefuse_comfyui/nodes/mask_tap.py
+++ b/freefuse_comfyui/nodes/mask_tap.py
@@ -226,8 +226,15 @@ def _resolve_image_ref_path(path_like: Optional[str], ref_type: Optional[str]) -
 
 def _load_mask_from_image_ref(
     image_ref,
-    target_h: int,
-    target_w: int,
+    target_h: Optional[int] = None,
+    target_w: Optional[int] = None,
+    *,
+    use_alpha: bool = True,
+    invert_alpha: bool = True,
+    prefer_alpha: bool = False,
+    threshold: float = _MASK_BINARY_THRESHOLD,
+    binarize: bool = True,
+    warning_prefix: str = "[FreeFuseMaskTap]",
 ) -> Optional[torch.Tensor]:
     if Image is None:
         return None
@@ -241,19 +248,67 @@ def _load_mask_from_image_ref(
         with Image.open(resolved_path) as img:
             gray = np.array(img.convert("L")).astype(np.float32) / 255.0
             mask_2d = torch.from_numpy(gray)
-            if "A" in img.getbands():
+            if bool(use_alpha) and "A" in img.getbands():
                 alpha = np.array(img.getchannel("A")).astype(np.float32) / 255.0
-                alpha_mask = 1.0 - torch.from_numpy(alpha)
-                # Prefer visible grayscale content. Fallback to alpha when RGB is flat.
-                if float(np.var(gray)) <= _MASK_SIGNAL_EPS and float(np.var(alpha)) > _MASK_SIGNAL_EPS:
+                alpha_values = 1.0 - alpha if bool(invert_alpha) else alpha
+                alpha_mask = torch.from_numpy(alpha_values)
+                gray_has_signal = float(np.var(gray)) > _MASK_SIGNAL_EPS
+                alpha_has_signal = float(np.var(alpha)) > _MASK_SIGNAL_EPS
+                if bool(prefer_alpha) or (alpha_has_signal and not gray_has_signal):
                     mask_2d = alpha_mask
         mask_2d = mask_2d.float()
         if mask_2d.dim() != 2:
             return None
-        mask_2d = _resize_2d(mask_2d, target_h, target_w, mode="nearest")
-        return _binarize_2d(mask_2d)
+        if target_h is not None and target_w is not None:
+            mask_2d = _resize_2d(mask_2d, int(target_h), int(target_w), mode="nearest")
+        if bool(binarize):
+            mask_2d = _binarize_2d(mask_2d, threshold)
+        return mask_2d
     except Exception as e:
-        print(f"[FreeFuseMaskTap] Warning: failed to load edited mask '{resolved_path}': {e}")
+        print(f"{warning_prefix} Warning: failed to load mask '{resolved_path}': {e}")
+        return None
+
+
+def _load_mask_from_image_tensor(
+    image_tensor,
+    target_h: Optional[int] = None,
+    target_w: Optional[int] = None,
+    *,
+    use_alpha: bool = True,
+    invert_alpha: bool = False,
+    threshold: float = _MASK_BINARY_THRESHOLD,
+    binarize: bool = True,
+    warning_prefix: str = "[FreeFuseMaskBankFromImages]",
+) -> Optional[torch.Tensor]:
+    if not isinstance(image_tensor, torch.Tensor):
+        return None
+
+    try:
+        img = image_tensor.detach().float()
+        if img.dim() == 4:
+            if img.shape[0] < 1:
+                return None
+            img = img[0]
+        if img.dim() != 3 or img.shape[-1] < 1:
+            return None
+
+        channels = int(img.shape[-1])
+        if bool(use_alpha) and channels >= 4:
+            alpha = img[..., 3].clamp(0.0, 1.0)
+            mask_2d = 1.0 - alpha if bool(invert_alpha) else alpha
+        elif channels >= 3:
+            mask_2d = img[..., 0].clamp(0.0, 1.0)
+        else:
+            mask_2d = img[..., 0].clamp(0.0, 1.0)
+
+        mask_2d = mask_2d.float()
+        if target_h is not None and target_w is not None:
+            mask_2d = _resize_2d(mask_2d, int(target_h), int(target_w), mode="nearest")
+        if bool(binarize):
+            mask_2d = _binarize_2d(mask_2d, threshold)
+        return mask_2d
+    except Exception as e:
+        print(f"{warning_prefix} Warning: failed to read image tensor: {e}")
         return None
 
 
@@ -302,6 +357,157 @@ def _build_mask_editor_ui_images(slot_masks_2d: List[torch.Tensor]) -> List[Dict
         refs.append({"filename": filename, "subfolder": "", "type": "temp"})
 
     return refs
+
+
+class FreeFuseMaskBankFromImages:
+    """
+    Build a FREEFUSE_MASKS bank directly from user-supplied mask images.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "freefuse_data": ("FREEFUSE_DATA",),
+            },
+            "optional": {
+                "mask_image_00": ("IMAGE",),
+                "mask_image_01": ("IMAGE",),
+                "mask_image_02": ("IMAGE",),
+                "mask_image_03": ("IMAGE",),
+                "mask_image_04": ("IMAGE",),
+                "mask_image_05": ("IMAGE",),
+                "mask_image_06": ("IMAGE",),
+                "mask_image_07": ("IMAGE",),
+                "mask_image_08": ("IMAGE",),
+                "mask_image_09": ("IMAGE",),
+                "width": ("INT", {"default": 64, "min": 0, "max": 16384, "step": 8}),
+                "height": ("INT", {"default": 64, "min": 0, "max": 16384, "step": 8}),
+                "use_alpha": ("BOOLEAN", {"default": True}),
+                "invert_alpha": ("BOOLEAN", {"default": False}),
+                "threshold": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
+            },
+        }
+
+    RETURN_TYPES = ("FREEFUSE_MASKS", "STRING", "IMAGE")
+    RETURN_NAMES = ("mask_bank", "slot_names", "slot_mask_images")
+    FUNCTION = "build_mask_bank"
+    CATEGORY = "FreeFuse/Utils"
+
+    @staticmethod
+    def _adapter_names(freefuse_data) -> List[str]:
+        names: List[str] = []
+        seen = set()
+        adapters = freefuse_data.get("adapters", []) if isinstance(freefuse_data, dict) else []
+        if not isinstance(adapters, list):
+            return names
+        for adapter in adapters:
+            if isinstance(adapter, dict):
+                name = adapter.get("name")
+            else:
+                name = adapter
+            if isinstance(name, str) and name and name not in seen:
+                names.append(name)
+                seen.add(name)
+        return names
+
+    @staticmethod
+    def _target_size(width, height) -> Tuple[Optional[int], Optional[int]]:
+        try:
+            w = int(width)
+            h = int(height)
+        except Exception:
+            w, h = 0, 0
+        if w > 0 and h > 0:
+            return h, w
+        if w > 0 or h > 0:
+            print("[FreeFuseMaskBankFromImages] Warning: width and height must both be nonzero; keeping native mask size")
+        return None, None
+
+    def build_mask_bank(
+        self,
+        freefuse_data,
+        width=64,
+        height=64,
+        use_alpha=True,
+        invert_alpha=False,
+        threshold=0.5,
+        **kwargs,
+    ):
+        adapter_names = self._adapter_names(freefuse_data)
+        target_h, target_w = self._target_size(width, height)
+        masks: Dict[str, torch.Tensor] = {}
+        slot_lines: List[str] = []
+        slot_masks: List[Optional[torch.Tensor]] = []
+
+        for i in range(10):
+            adapter_name = adapter_names[i] if i < len(adapter_names) else ""
+            slot_lines.append(f"{i:02d}:{adapter_name}")
+            if not adapter_name:
+                slot_masks.append(None)
+                continue
+
+            key = f"mask_image_{i:02d}"
+            image_tensor = kwargs.get(key)
+            if image_tensor is None:
+                slot_masks.append(None)
+                continue
+
+            mask = _load_mask_from_image_tensor(
+                image_tensor=image_tensor,
+                target_h=target_h,
+                target_w=target_w,
+                use_alpha=bool(use_alpha),
+                invert_alpha=bool(invert_alpha),
+                threshold=float(threshold),
+                binarize=True,
+                warning_prefix="[FreeFuseMaskBankFromImages]",
+            )
+            if mask is None:
+                print(f"[FreeFuseMaskBankFromImages] Warning: failed to read {key} for adapter '{adapter_name}'")
+                slot_masks.append(None)
+                continue
+            masks[adapter_name] = mask.float()
+            slot_masks.append(mask.float())
+
+        mask_bank = {
+            "masks": masks,
+            "similarity_maps": {},
+            "metadata": {
+                "adapter_names": adapter_names,
+                "source": "mask_images",
+            },
+        }
+        slot_names = "\n".join(slot_lines)
+
+        preview_h, preview_w = 64, 64
+        if target_h is not None and target_w is not None:
+            preview_h, preview_w = int(target_h), int(target_w)
+        else:
+            for mask in slot_masks:
+                hw = _mask_hw(mask)
+                if hw is not None:
+                    preview_h, preview_w = hw
+                    break
+
+        slot_images: List[torch.Tensor] = []
+        for mask in slot_masks:
+            m2d = _to_2d_mask(mask)
+            if m2d is None:
+                m2d = torch.zeros((preview_h, preview_w), dtype=torch.float32)
+            else:
+                m2d = _resize_2d(m2d.float(), preview_h, preview_w, mode="nearest")
+            img = (
+                _binarize_2d(m2d)
+                .clamp(0.0, 1.0)
+                .detach()
+                .cpu()
+                .unsqueeze(-1)
+                .repeat(1, 1, 3)
+            )
+            slot_images.append(img)
+        slot_mask_images = torch.stack(slot_images, dim=0)
+        return (mask_bank, slot_names, slot_mask_images)
 
 
 class FreeFuseMaskTap:
@@ -630,11 +836,13 @@ class FreeFuseMaskReassemble:
 
 
 NODE_CLASS_MAPPINGS = {
+    "FreeFuseMaskBankFromImages": FreeFuseMaskBankFromImages,
     "FreeFuseMaskTap": FreeFuseMaskTap,
     "FreeFuseMaskReassemble": FreeFuseMaskReassemble,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
+    "FreeFuseMaskBankFromImages": "FreeFuse Mask Bank From Images",
     "FreeFuseMaskTap": "FreeFuse Mask Tap",
     "FreeFuseMaskReassemble": "FreeFuse Mask Reassemble",
 }

--- a/freefuse_comfyui/tests/test_mask_tap.py
+++ b/freefuse_comfyui/tests/test_mask_tap.py
@@ -27,10 +27,63 @@ def _module():
     return _load_module("freefuse_mask_tap_for_test", path)
 
 
+def _freefuse_dir():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(script_dir)
+
+
 def _unwrap_result(value):
     if isinstance(value, dict) and "result" in value:
         return value["result"]
     return value
+
+
+def _freefuse_data(*names):
+    return {"adapters": [{"name": name} for name in names]}
+
+
+def _save_split_alpha(path, left_alpha, right_alpha):
+    img = Image.new("RGBA", (4, 2), (0, 0, 0, 255))
+    px = img.load()
+    for y in range(2):
+        for x in range(4):
+            alpha = left_alpha if x < 2 else right_alpha
+            gray = 255 if x < 2 else 0
+            px[x, y] = (gray, gray, gray, alpha)
+    img.save(path)
+
+
+def _solid_rgb_image(height, width, value, *, batch=True):
+    img = torch.full((height, width, 3), float(value), dtype=torch.float32)
+    return img.unsqueeze(0) if batch else img
+
+
+def _checker_rgb_image(*, batch=True):
+    img = torch.tensor(
+        [
+            [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]],
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        ],
+        dtype=torch.float32,
+    )
+    return img.unsqueeze(0) if batch else img
+
+
+def _split_rgba_image(left_alpha, right_alpha):
+    img = torch.zeros((1, 2, 4, 4), dtype=torch.float32)
+    img[:, :, :2, :3] = 1.0
+    img[:, :, 2:, :3] = 0.0
+    img[:, :, :2, 3] = float(left_alpha)
+    img[:, :, 2:, 3] = float(right_alpha)
+    return img
+
+
+def _slot_names(*names):
+    lines = []
+    for i in range(10):
+        name = names[i] if i < len(names) else ""
+        lines.append(f"{i:02d}:{name}")
+    return "\n".join(lines)
 
 
 def test_tap_order_from_freefuse_data():
@@ -257,6 +310,221 @@ def test_ui_editor_image_contains_visible_rgb_and_alpha_mask():
         mod.folder_paths = original_folder_paths
 
 
+def test_load_mask_prefer_alpha_uses_flat_alpha():
+    mod = _module()
+
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "flat_alpha.png")
+        Image.new("RGBA", (4, 2), (255, 255, 255, 0)).save(path)
+
+        mask = mod._load_mask_from_image_ref(
+            path,
+            use_alpha=True,
+            invert_alpha=False,
+            prefer_alpha=True,
+        )
+
+    assert mask.shape == (2, 4)
+    assert torch.allclose(mask, torch.zeros(2, 4), atol=1e-6)
+
+
+def test_mask_bank_from_images_builds_bank_in_adapter_order():
+    mod = _module()
+    node = mod.FreeFuseMaskBankFromImages()
+
+    out, slot_names, slot_mask_images = node.build_mask_bank(
+        freefuse_data=_freefuse_data("first", "second"),
+        mask_image_00=_solid_rgb_image(2, 3, 1.0),
+        mask_image_01=_solid_rgb_image(2, 3, 0.0),
+        width=0,
+        height=0,
+    )
+
+    assert slot_names == _slot_names("first", "second")
+    assert slot_mask_images.shape == (10, 2, 3, 3)
+    assert torch.allclose(slot_mask_images[0, :, :, 0], torch.ones(2, 3), atol=1e-6)
+    assert torch.allclose(slot_mask_images[1, :, :, 0], torch.zeros(2, 3), atol=1e-6)
+    assert torch.allclose(slot_mask_images[2:, :, :, 0], torch.zeros(8, 2, 3), atol=1e-6)
+    assert list(out["masks"].keys()) == ["first", "second"]
+    assert torch.allclose(out["masks"]["first"], torch.ones(2, 3), atol=1e-6)
+    assert torch.allclose(out["masks"]["second"], torch.zeros(2, 3), atol=1e-6)
+    assert out["similarity_maps"] == {}
+    assert out["metadata"]["adapter_names"] == ["first", "second"]
+    assert out["metadata"]["source"] == "mask_images"
+
+
+def test_mask_bank_from_images_defaults_to_64x64():
+    mod = _module()
+    node = mod.FreeFuseMaskBankFromImages()
+
+    out, _, slot_mask_images = node.build_mask_bank(
+        freefuse_data=_freefuse_data("default_size"),
+        mask_image_00=_solid_rgb_image(2, 3, 1.0),
+    )
+
+    assert out["masks"]["default_size"].shape == (64, 64)
+    assert slot_mask_images.shape == (10, 64, 64, 3)
+
+
+def test_mask_bank_from_images_alpha_defaults_invert_and_rgb_fallback():
+    mod = _module()
+    node = mod.FreeFuseMaskBankFromImages()
+    image = _split_rgba_image(left_alpha=0.0, right_alpha=1.0)
+
+    normal, _, _ = node.build_mask_bank(
+        freefuse_data=_freefuse_data("alpha_lora"),
+        mask_image_00=image,
+        width=0,
+        height=0,
+    )
+    inverted, _, _ = node.build_mask_bank(
+        freefuse_data=_freefuse_data("alpha_lora"),
+        mask_image_00=image,
+        width=0,
+        height=0,
+        invert_alpha=True,
+    )
+    rgb_fallback, _, _ = node.build_mask_bank(
+        freefuse_data=_freefuse_data("alpha_lora"),
+        mask_image_00=image,
+        width=0,
+        height=0,
+        use_alpha=False,
+    )
+
+    normal_mask = normal["masks"]["alpha_lora"]
+    inverted_mask = inverted["masks"]["alpha_lora"]
+    rgb_mask = rgb_fallback["masks"]["alpha_lora"]
+
+    assert torch.allclose(normal_mask[:, :2], torch.zeros(2, 2), atol=1e-6)
+    assert torch.allclose(normal_mask[:, 2:], torch.ones(2, 2), atol=1e-6)
+    assert torch.allclose(inverted_mask[:, :2], torch.ones(2, 2), atol=1e-6)
+    assert torch.allclose(inverted_mask[:, 2:], torch.zeros(2, 2), atol=1e-6)
+    assert torch.allclose(rgb_mask[:, :2], torch.ones(2, 2), atol=1e-6)
+    assert torch.allclose(rgb_mask[:, 2:], torch.zeros(2, 2), atol=1e-6)
+
+
+def test_mask_bank_from_images_rgb_uses_red_channel():
+    mod = _module()
+    node = mod.FreeFuseMaskBankFromImages()
+    image = torch.tensor(
+        [
+            [
+                [[0.0, 1.0, 0.0], [1.0, 0.0, 0.0]],
+                [[0.0, 0.0, 1.0], [1.0, 1.0, 1.0]],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+
+    out, _, slot_mask_images = node.build_mask_bank(
+        freefuse_data=_freefuse_data("rgb_lora"),
+        mask_image_00=image,
+        width=0,
+        height=0,
+    )
+
+    expected = torch.tensor([[0.0, 1.0], [0.0, 1.0]], dtype=torch.float32)
+    assert torch.allclose(out["masks"]["rgb_lora"], expected, atol=1e-6)
+    assert torch.allclose(slot_mask_images[0, :, :, 0], expected, atol=1e-6)
+
+
+def test_mask_bank_from_images_resizes_and_skips_empty_slots():
+    mod = _module()
+    node = mod.FreeFuseMaskBankFromImages()
+
+    out, slot_names, slot_mask_images = node.build_mask_bank(
+        freefuse_data=_freefuse_data("empty_slot", "filled_slot"),
+        mask_image_01=_checker_rgb_image(batch=False),
+        width=4,
+        height=4,
+    )
+
+    assert slot_names == _slot_names("empty_slot", "filled_slot")
+    assert slot_mask_images.shape == (10, 4, 4, 3)
+    assert torch.allclose(slot_mask_images[0, :, :, 0], torch.zeros(4, 4), atol=1e-6)
+    assert torch.allclose(slot_mask_images[1, :2, :2, 0], torch.ones(2, 2), atol=1e-6)
+    assert torch.allclose(slot_mask_images[1, :2, 2:, 0], torch.zeros(2, 2), atol=1e-6)
+    assert torch.allclose(slot_mask_images[1, 2:, :2, 0], torch.zeros(2, 2), atol=1e-6)
+    assert torch.allclose(slot_mask_images[1, 2:, 2:, 0], torch.ones(2, 2), atol=1e-6)
+    assert "empty_slot" not in out["masks"]
+    assert list(out["masks"].keys()) == ["filled_slot"]
+    mask = out["masks"]["filled_slot"]
+    assert mask.shape == (4, 4)
+    assert torch.allclose(mask[:2, :2], torch.ones(2, 2), atol=1e-6)
+    assert torch.allclose(mask[:2, 2:], torch.zeros(2, 2), atol=1e-6)
+    assert torch.allclose(mask[2:, :2], torch.zeros(2, 2), atol=1e-6)
+    assert torch.allclose(mask[2:, 2:], torch.ones(2, 2), atol=1e-6)
+    assert out["metadata"]["adapter_names"] == ["empty_slot", "filled_slot"]
+
+
+def test_mask_bank_from_images_uses_first_image_from_batch():
+    mod = _module()
+    node = mod.FreeFuseMaskBankFromImages()
+    batch = torch.stack(
+        [
+            torch.zeros((2, 2, 3), dtype=torch.float32),
+            torch.ones((2, 2, 3), dtype=torch.float32),
+        ],
+        dim=0,
+    )
+
+    out, slot_names, slot_mask_images = node.build_mask_bank(
+        freefuse_data=_freefuse_data("batched"),
+        mask_image_00=batch,
+        width=0,
+        height=0,
+    )
+
+    assert slot_names == _slot_names("batched")
+    assert slot_mask_images.shape == (10, 2, 2, 3)
+    assert torch.allclose(slot_mask_images[0], torch.zeros(2, 2, 3), atol=1e-6)
+    assert torch.allclose(out["masks"]["batched"], torch.zeros(2, 2), atol=1e-6)
+
+
+def test_mask_bank_from_images_local_registration():
+    mod = _module()
+
+    assert mod.NODE_CLASS_MAPPINGS["FreeFuseMaskBankFromImages"] is mod.FreeFuseMaskBankFromImages
+    assert mod.NODE_DISPLAY_NAME_MAPPINGS["FreeFuseMaskBankFromImages"] == "FreeFuse Mask Bank From Images"
+    assert mod.FreeFuseMaskBankFromImages.RETURN_TYPES == ("FREEFUSE_MASKS", "STRING", "IMAGE")
+    assert mod.FreeFuseMaskBankFromImages.RETURN_NAMES == ("mask_bank", "slot_names", "slot_mask_images")
+
+    inputs = mod.FreeFuseMaskBankFromImages.INPUT_TYPES()
+    for i in range(10):
+        assert inputs["optional"][f"mask_image_{i:02d}"][0] == "IMAGE"
+    assert inputs["optional"]["width"][1]["default"] == 64
+    assert inputs["optional"]["height"][1]["default"] == 64
+
+
+def test_mask_bank_from_images_package_export_registration():
+    freefuse_dir = _freefuse_dir()
+    with open(os.path.join(freefuse_dir, "nodes", "__init__.py"), "r", encoding="utf-8") as f:
+        nodes_init = f.read()
+    with open(os.path.join(freefuse_dir, "__init__.py"), "r", encoding="utf-8") as f:
+        package_init = f.read()
+
+    assert "FreeFuseMaskBankFromImages" in nodes_init
+    assert '"FreeFuseMaskBankFromImages": FreeFuseMaskBankFromImages' in nodes_init
+    assert '"FreeFuseMaskBankFromImages": "FreeFuse Mask Bank From Images"' in nodes_init
+    assert "FreeFuseMaskBankFromImages" in package_init
+
+
+def test_mask_bank_from_images_no_adapters_returns_empty_bank():
+    mod = _module()
+    node = mod.FreeFuseMaskBankFromImages()
+
+    out, slot_names, slot_mask_images = node.build_mask_bank(freefuse_data={"adapters": []})
+
+    assert out["masks"] == {}
+    assert out["similarity_maps"] == {}
+    assert out["metadata"]["adapter_names"] == []
+    assert out["metadata"]["source"] == "mask_images"
+    assert slot_names == _slot_names()
+    assert slot_mask_images.shape == (10, 64, 64, 3)
+    assert torch.allclose(slot_mask_images, torch.zeros(10, 64, 64, 3), atol=1e-6)
+
+
 def run_all_tests():
     test_tap_order_from_freefuse_data()
     test_reassemble_preserve_and_resize()
@@ -267,6 +535,16 @@ def run_all_tests():
     test_tap_user_edit_ref_requires_matching_phase1_seed()
     test_tap_legacy_untagged_edit_ref_ignored_when_phase1_seed_present()
     test_ui_editor_image_contains_visible_rgb_and_alpha_mask()
+    test_load_mask_prefer_alpha_uses_flat_alpha()
+    test_mask_bank_from_images_builds_bank_in_adapter_order()
+    test_mask_bank_from_images_defaults_to_64x64()
+    test_mask_bank_from_images_alpha_defaults_invert_and_rgb_fallback()
+    test_mask_bank_from_images_rgb_uses_red_channel()
+    test_mask_bank_from_images_resizes_and_skips_empty_slots()
+    test_mask_bank_from_images_uses_first_image_from_batch()
+    test_mask_bank_from_images_local_registration()
+    test_mask_bank_from_images_package_export_registration()
+    test_mask_bank_from_images_no_adapters_returns_empty_bank()
     print("All mask tap/reassemble tests passed.")
 
 


### PR DESCRIPTION
Non-square images (e.g. 1280x720) produce attention maps with N tokens that don't exactly match h*w at any downsampling scale due to extra non-spatial tokens (register/class tokens). For example, 1280x720 at 2x downscale gives 80x45=3600 spatial tokens but N=3616 (16 extra).

The old code fell through to a sqrt(N) fallback, computing h=w=60, then crashed on view(60,60) since 3600 != 3616.

Fix: after trying exact scale matches, try approximate matches where h*w < N with the difference under 5% of spatial size. Strip the extra non-spatial tokens before reshaping.