### PR TITLE
Add krea2 support

### DIFF
--- a/freefuse_core/krea2_support.py
+++ b/freefuse_core/krea2_support.py
@@ -1,0 +1,440 @@
+"""
+FreeFuse Krea 2 Support (comfy/ldm/krea2/model.py :: SingleStreamDiT)
+
+Krea 2 is a single-stream DiT:
+    combined = torch.cat((context, img), dim=1)          # [txt, img] layout, same as Z-Image
+    for block in self.blocks:
+        combined = block(combined, tvec, freqs, None, transformer_options=...)
+
+    SingleStreamBlock.forward(x, vec, freqs, mask=None, transformer_options={})
+        prescale, preshift, pregate, postscale, postshift, postgate = self.mod(vec)
+        attn_in = (1 + prescale) * self.prenorm(x) + preshift
+        attn_out = self.attn(attn_in, freqs, mask, transformer_options=...)
+        x = x + pregate * attn_out
+        ...
+
+    Attention.forward(x, freqs=None, mask=None, transformer_options={})
+        q, k, v, gate = wq(x), wk(x), wv(x), gate(x)
+        q, k = qknorm(q, k)
+        q, k = apply_rope(q, k, freqs)
+        # GQA expansion (repeat_interleave)
+        out = optimized_attention_masked(q, k, v, heads, mask=mask, skip_reshape=True, ...)
+        return wo(out * sigmoid(gate))
+
+KEY DIFFERENCE FROM FLUX / Z-IMAGE:
+Krea2's Attention/Block already thread a `mask` argument through to the real attention
+call, but the top-level forward loop always passes `mask=None`. So for Phase 2 (bias
+injection) we do NOT need to reimplement RoPE/GQA/attention ourselves - we just hijack
+that unused `mask` argument via a forward_pre_hook on `block.attn`, right before the
+*original*, unmodified Attention.forward runs.
+
+For Phase 1 (mask collection) we still need to manually recompute q/k, because
+Attention.forward doesn't expose them - only the final projected output.
+
+IMPORTANT - lifecycle: Krea2 has no ComfyUI replace-patch system, so these hooks are
+plain torch module hooks attached directly to the underlying nn.Module (shared across
+ModelPatcher clones). ALWAYS call .remove() on the returned replacer object after
+sampling finishes (in a try/finally), or the hooks will leak into later generations.
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+from .attention_replace import (
+    FreeFuseState,
+    compute_z_image_similarity_maps_with_qkv,  # architecture-agnostic, reused as-is
+)
+from .tensor_debug import format_tensor_stats
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Phase 1: similarity-map collection
+# ──────────────────────────────────────────────────────────────────────────
+
+class FreeFuseKrea2BlockReplace:
+    """
+    QKV-based similarity collector for Krea 2 (SingleStreamDiT).
+
+    Uses plain PyTorch hooks (no ComfyUI replace-patch system needed):
+      1) forward_hook on `diffusion_model.txtfusion` captures cap_len (text length)
+         for the current forward pass - txtfusion always runs before the block loop.
+      2) forward_pre_hook on each target `diffusion_model.blocks[i]` captures the
+         block's inputs (x, vec, freqs) and, on the target step, manually recomputes
+         QKV/RoPE/GQA/attention-output to build similarity maps (mirrors
+         comfy.ldm.krea2.model.Attention.forward exactly, read-only - never modifies
+         the actual forward pass).
+    """
+
+    def __init__(
+        self,
+        state: FreeFuseState,
+        diffusion_model,
+        block_entries: List[Tuple[int, Any]],
+    ):
+        self.state = state
+        self.diffusion_model = diffusion_model
+        self._blocks: Dict[int, Any] = {int(idx): blk for idx, blk in block_entries}
+        self._target_blocks = set(self._blocks.keys())
+        self._cap_len: Optional[int] = None
+        self._hook_handles: List[Any] = []
+
+    def install(self) -> None:
+        txtfusion = getattr(self.diffusion_model, "txtfusion", None)
+        if txtfusion is None:
+            logging.error("[FreeFuse Krea2] Cannot find `txtfusion` on diffusion model")
+            return
+
+        self._hook_handles.append(
+            txtfusion.register_forward_hook(self._txtfusion_hook, with_kwargs=True)
+        )
+        for block_index, block in self._blocks.items():
+            self._hook_handles.append(
+                block.register_forward_pre_hook(
+                    self._make_pre_hook(block_index), with_kwargs=True
+                )
+            )
+        logging.info(
+            f"[FreeFuse Krea2] Installed QKV-based collectors on blocks "
+            f"{sorted(self._target_blocks)}"
+        )
+
+    def remove(self) -> None:
+        for h in self._hook_handles:
+            h.remove()
+        self._hook_handles.clear()
+
+    def _txtfusion_hook(self, module, args, kwargs, output):
+        # TextFusionTransformer.forward returns (B, cap_len, txtdim)
+        if torch.is_tensor(output):
+            self._cap_len = int(output.shape[1])
+
+    def _make_pre_hook(self, block_index: int) -> Callable:
+        def _pre_hook(module, args, kwargs):
+            state = self.state
+            if state.phase != "collect":
+                return None
+            # SingleStreamBlock.forward(self, x, vec, freqs, mask=None, transformer_options={})
+            if len(args) < 3:
+                return None
+            x, vec, freqs = args[0], args[1], args[2]
+            transformer_options = (kwargs or {}).get("transformer_options", {})
+            current_step = transformer_options.get("sigmas_index", state.current_step)
+
+            if not state.is_collect_step(current_step, block_index):
+                return None
+
+            try:
+                self._extract_and_compute(module, x, vec, freqs, block_index)
+            except Exception as e:
+                logging.error(
+                    f"[FreeFuse Krea2] QKV extraction failed at block {block_index}: {e}"
+                )
+                import traceback
+                traceback.print_exc()
+            return None  # never modify the Phase-1 forward pass
+
+        return _pre_hook
+
+    def _extract_and_compute(self, block, x, vec, freqs, block_index: int) -> None:
+        from comfy.ldm.flux.math import apply_rope
+
+        state = self.state
+        cap_len = self._cap_len
+        if cap_len is None:
+            logging.warning("[FreeFuse Krea2] cap_len not captured yet; skipping collection")
+            return
+
+        seqlen_total = x.shape[1]
+        img_len = seqlen_total - cap_len
+        if img_len <= 0:
+            logging.warning(f"[FreeFuse Krea2] Non-positive img_len ({img_len}); skipping")
+            return
+
+        # ---- Mirror SingleStreamBlock.forward's pre-attention modulation ----
+        prescale, preshift, pregate, postscale, postshift, postgate = block.mod(vec)
+        attn_in = (1 + prescale) * block.prenorm(x) + preshift
+
+        # ---- Mirror Attention.forward up to (not including) optimized_attention_masked ----
+        attn = block.attn
+        q = attn.wq(attn_in)
+        k = attn.wk(attn_in)
+        v = attn.wv(attn_in)
+
+        q = rearrange(q, "B L (H D) -> B H L D", H=attn.heads)
+        k = rearrange(k, "B L (H D) -> B H L D", H=attn.kvheads)
+        v = rearrange(v, "B L (H D) -> B H L D", H=attn.kvheads)
+        q, k = attn.qknorm(q, k)
+        if freqs is not None:
+            q, k = apply_rope(q, k, freqs)
+
+        if attn.kvheads != attn.heads:
+            rep = attn.heads // attn.kvheads
+            k = k.repeat_interleave(rep, dim=1)
+            v = v.repeat_interleave(rep, dim=1)
+
+        # (B, H, L, D) -> (B, L, H, D) to match compute_z_image_similarity_maps_with_qkv
+        q_bld = q.transpose(1, 2)
+        k_bld = k.transpose(1, 2)
+
+        attn_out_4d = F.scaled_dot_product_attention(q, k, v, dropout_p=0.0)  # (B, H, L, D)
+        attn_out = attn_out_4d.transpose(1, 2).reshape(x.shape[0], seqlen_total, -1)
+
+        # Krea2 layout is [txt(cap_len), img(img_len)] - same convention as Z-Image.
+        img_q = q_bld[:, cap_len:, :, :]
+        txt_k = k_bld[:, :cap_len, :, :]
+        img_attn_out = attn_out[:, cap_len:, :]
+
+        if state.token_pos_maps:
+            sim_maps = compute_z_image_similarity_maps_with_qkv(
+                img_q=img_q,
+                txt_k=txt_k,
+                img_attn_out=img_attn_out,
+                cap_len=cap_len,
+                img_len=img_len,
+                token_pos_maps=state.token_pos_maps,
+                top_k_ratio=state.top_k_ratio,
+                temperature=state.temperature,
+                n_heads=attn.heads,
+            )
+            state.similarity_maps.update(sim_maps)
+            if "block_similarity_maps" in state.collected_outputs:
+                state.collected_outputs["block_similarity_maps"][block_index] = dict(sim_maps)
+            if hasattr(state, "collected_blocks"):
+                state.collected_blocks.add(block_index)
+
+            logging.info(
+                f"[FreeFuse Krea2] Collected {len(sim_maps)} similarity maps at block {block_index}"
+            )
+            for name, sm in sim_maps.items():
+                logging.info(f"   {name}: {format_tensor_stats(sm, include_shape=True)}")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Phase 2: attention-bias injection
+# ──────────────────────────────────────────────────────────────────────────
+
+class FreeFuseKrea2BiasBlockReplace:
+    """
+    Injects attention bias into Krea 2 by hijacking the `mask` argument that
+    Attention.forward already threads through to optimized_attention_masked.
+
+    We do NOT reimplement QKV/RoPE/GQA here - we overwrite the `mask` kwarg/arg
+    right before the *original*, unmodified Attention.forward runs, via a
+    forward_pre_hook on `block.attn`.
+    """
+
+    def __init__(
+        self,
+        lora_masks: Dict[str, torch.Tensor],
+        token_pos_maps: Dict[str, List[List[int]]],
+        config,
+        diffusion_model,
+        block_indices: List[int],
+    ):
+        self.lora_masks = lora_masks
+        self.token_pos_maps = token_pos_maps
+        self.config = config
+        self.diffusion_model = diffusion_model
+        self.block_indices = {int(i) for i in block_indices}
+        self._cap_len: Optional[int] = None
+        self._bias_cache: Dict[Tuple[int, int], Optional[torch.Tensor]] = {}
+        self._hook_handles: List[Any] = []
+        self._construct_attention_bias = None
+
+    def install(self) -> None:
+        from .attention_bias import construct_attention_bias
+        self._construct_attention_bias = construct_attention_bias
+
+        txtfusion = getattr(self.diffusion_model, "txtfusion", None)
+        if txtfusion is None:
+            logging.error("[FreeFuse Krea2] Cannot find `txtfusion` for bias injection")
+            return
+        self._hook_handles.append(
+            txtfusion.register_forward_hook(self._txtfusion_hook, with_kwargs=True)
+        )
+
+        blocks = getattr(self.diffusion_model, "blocks", None)
+        if blocks is None:
+            logging.error("[FreeFuse Krea2] Cannot find `blocks` for bias injection")
+            return
+
+        for idx in self.block_indices:
+            if idx < 0 or idx >= len(blocks):
+                continue
+            attn_module = blocks[idx].attn
+            self._hook_handles.append(
+                attn_module.register_forward_pre_hook(
+                    self._make_bias_prehook(idx), with_kwargs=True
+                )
+            )
+        logging.info(
+            f"[FreeFuse Krea2] Installed bias injection on blocks {sorted(self.block_indices)}"
+        )
+
+    def remove(self) -> None:
+        for h in self._hook_handles:
+            h.remove()
+        self._hook_handles.clear()
+
+    def _txtfusion_hook(self, module, args, kwargs, output):
+        if torch.is_tensor(output):
+            self._cap_len = int(output.shape[1])
+
+    def _get_or_build_bias(self, img_len, cap_len, device, dtype):
+        key = (img_len, cap_len)
+        if key in self._bias_cache:
+            cached = self._bias_cache[key]
+            return cached.to(device=device, dtype=dtype) if cached is not None else None
+
+        bias = self._construct_attention_bias(
+            lora_masks=self.lora_masks,
+            token_pos_maps=self.token_pos_maps,
+            txt_seq_len=cap_len,
+            img_seq_len=img_len,
+            bias_scale=self.config.bias_scale,
+            positive_bias_scale=self.config.positive_bias_scale,
+            bidirectional=self.config.bidirectional,
+            use_positive_bias=self.config.use_positive_bias,
+            device=device,
+            dtype=dtype,
+        )
+        self._bias_cache[key] = bias
+        return bias
+
+    def _make_bias_prehook(self, block_index: int) -> Callable:
+        def _prehook(module, args, kwargs):
+            # Attention.forward(self, x, freqs=None, mask=None, transformer_options={})
+            if not args:
+                return None
+            x = args[0]
+            cap_len = self._cap_len
+            if cap_len is None:
+                return None
+            seqlen = x.shape[1]
+            img_len = seqlen - cap_len
+            if img_len <= 0:
+                return None
+
+            bias = self._get_or_build_bias(img_len, cap_len, x.device, x.dtype)
+            if bias is None:
+                return None
+            if bias.dim() == 3:
+                bias = bias.unsqueeze(1)  # -> (B, 1, seq, seq), broadcasts over heads
+
+            new_args = list(args)
+            new_kwargs = dict(kwargs) if kwargs else {}
+            if len(new_args) >= 3:
+                new_args[2] = bias
+            else:
+                new_kwargs["mask"] = bias
+            return tuple(new_args), new_kwargs
+
+        return _prehook
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Entry points (mirror apply_freefuse_replace_patches / apply_attention_bias_patches)
+# ──────────────────────────────────────────────────────────────────────────
+
+def apply_krea2_replace_patches(
+    model,
+    state: FreeFuseState,
+    krea2_collect_blocks: Optional[List[int]] = None,
+) -> Optional[FreeFuseKrea2BlockReplace]:
+    """Install Phase-1 collection hooks on a Krea2 model. Returns the replacer
+    (caller MUST call .remove() when sampling finishes)."""
+    diffusion_model = model.model.diffusion_model
+    blocks = getattr(diffusion_model, "blocks", None)
+    if blocks is None:
+        logging.error("[FreeFuse Krea2] Cannot find Krea2 `blocks` in diffusion model")
+        return None
+
+    if krea2_collect_blocks is None:
+        krea2_collect_blocks = [state.collect_block]
+
+    max_idx = len(blocks) - 1
+    valid_blocks = [b for b in krea2_collect_blocks if 0 <= b <= max_idx]
+    if not valid_blocks:
+        fallback = min(max(state.collect_block, 0), max_idx)
+        logging.warning(
+            f"[FreeFuse Krea2] No valid blocks in requested range; falling back to {fallback}."
+        )
+        valid_blocks = [fallback]
+        state.collect_block = fallback
+        state.collect_block_end = fallback
+
+    block_entries = [(idx, blocks[idx]) for idx in valid_blocks]
+    replacer = FreeFuseKrea2BlockReplace(state, diffusion_model, block_entries)
+    replacer.install()
+    return replacer
+
+
+def apply_krea2_bias_patches(
+    model,
+    lora_masks: Dict[str, torch.Tensor],
+    token_pos_maps: Dict[str, List[List[int]]],
+    config,
+    block_indices: Optional[List[int]] = None,
+):
+    """
+    Install Phase-2 bias injection for Krea 2, scoped safely to `model.model_options`.
+
+    Krea2 has no per-ModelPatcher-clone replace-patch system (unlike Flux/Z-Image),
+    so raw hooks installed once here and left running would remain attached to the
+    *shared* underlying nn.Module for as long as the process lives - silently
+    corrupting any later, unrelated Krea2 generation that reuses the same
+    checkpoint (even without FreeFuse).
+
+    Instead we wrap `model_options["model_function_wrapper"]` - a ComfyUI extension
+    point called once per individual model forward call (each sampling step). We
+    install the bias hooks immediately before calling the real forward function
+    and remove them immediately after, inside the same call. That ties their
+    lifetime exactly to model_options on THIS model clone; a fresh `model.clone()`
+    used elsewhere never sees them.
+
+    Composes with any existing model_function_wrapper instead of overwriting it,
+    so this stays compatible with other custom nodes (e.g. ControlNet helpers).
+    """
+    diffusion_model = model.model.diffusion_model
+    blocks = getattr(diffusion_model, "blocks", None)
+    if blocks is None:
+        logging.error("[FreeFuse Krea2] Cannot find `blocks` for bias injection")
+        return None
+
+    if block_indices is None:
+        # Default: last half of blocks (mirrors Z-Image's "last_half" bias_blocks option).
+        n = len(blocks)
+        block_indices = list(range(n // 2, n))
+
+    previous_wrapper = model.model_options.get("model_function_wrapper")
+
+    def krea2_bias_wrapper(apply_model_fn, args):
+        replacer = FreeFuseKrea2BiasBlockReplace(
+            lora_masks, token_pos_maps, config, diffusion_model, block_indices
+        )
+        replacer.install()
+        try:
+            if previous_wrapper is not None:
+                return previous_wrapper(apply_model_fn, args)
+            return apply_model_fn(args["input"], args["timestep"], **args["c"])
+        finally:
+            replacer.remove()
+
+    model.model_options["model_function_wrapper"] = krea2_bias_wrapper
+    logging.info(
+        f"[FreeFuse Krea2] Registered per-call bias wrapper for blocks "
+        f"{sorted(set(int(i) for i in block_indices))} (scoped to this model clone only)"
+    )
+    return krea2_bias_wrapper
+
+
+__all__ = [
+    "FreeFuseKrea2BlockReplace",
+    "FreeFuseKrea2BiasBlockReplace",
+    "apply_krea2_replace_patches",
+    "apply_krea2_bias_patches",
+]

--- a/freefuse_core/token_utils.py
+++ b/freefuse_core/token_utils.py
@@ -21,6 +21,20 @@ LUMINA2_SYSTEM_PROMPT = (
 # Flux2.Klein should match diffusers apply_chat_template(..., enable_thinking=False).
 KLEIN_NO_THINK_TEMPLATE = "<|im_start|>user\n{}<|im_end|>\n<|im_start|>assistant\n"
 
+# Krea 2 (Qwen3-VL-4B, 12-layer tap). Must match comfy/text_encoders/krea2.py exactly,
+# including the hardcoded system message - Krea2's template is not user-configurable.
+KREA2_TEMPLATE = (
+    "<|im_start|>system\nDescribe the image by detailing the color, shape, size, "
+    "texture, quantity, text, spatial relationships of the objects and background:"
+    "<|im_end|>\n<|im_start|>user\n{}<|im_end|>\n<|im_start|>assistant\n"
+)
+
+# Special token ids used by Krea2TEModel.encode_token_weights to strip the
+# system + user-opening prefix before conditioning. Must match comfy/text_encoders/krea2.py.
+KREA2_IM_START_ID = 151644
+KREA2_USER_TOKEN_ID = 872
+KREA2_NEWLINE_TOKEN_ID = 198
+
 
 # Stopwords and punctuation to filter (shared between both methods)
 STOPWORDS = {
@@ -89,6 +103,11 @@ def _normalize_model_type(model_type: Optional[str]) -> Optional[str]:
         "sd1.5": "sd1",
         "sd2": "sd1",
         "sd2.x": "sd1",
+        "krea 2": "krea2",
+        "krea-2": "krea2",
+        "krea_2": "krea2",
+        "k2": "krea2",
+        "singlestreamdit": "krea2",
     }
     return aliases.get(value, value)
 
@@ -115,6 +134,8 @@ def detect_model_type_from_model(model) -> str:
         return "unknown"
 
     model_cls = core_model.__class__.__name__.lower()
+    if "krea2" in model_cls or "krea" in model_cls:
+        return "krea2"
     if "nextdit" in model_cls or "lumina" in model_cls:
         return "z_image"
     if "flux2" in model_cls:
@@ -126,6 +147,14 @@ def detect_model_type_from_model(model) -> str:
     dm = getattr(core_model, "diffusion_model", None)
     if dm is not None:
         dm_cls = dm.__class__.__name__.lower()
+        if "krea2" in dm_cls or "krea" in dm_cls:
+            return "krea2"
+        # `txtfusion` is unique to Krea2's SingleStreamDiT - check before the
+        # generic `layers` heuristic below since Krea2 doesn't use `layers`
+        # (it uses `blocks`), but this attribute check is the most reliable
+        # signal regardless of naming/refactors.
+        if hasattr(dm, "txtfusion"):
+            return "krea2"
         if "nextdit" in dm_cls or "lumina" in dm_cls:
             return "z_image"
         if "flux2" in dm_cls:
@@ -143,6 +172,8 @@ def detect_model_type_from_model(model) -> str:
     unet_cfg = getattr(model_cfg, "unet_config", None)
     if isinstance(unet_cfg, dict):
         image_model = str(unet_cfg.get("image_model", "")).lower()
+        if image_model == "krea2":
+            return "krea2"
         if image_model == "flux2":
             return "flux2"
         if image_model == "flux":
@@ -181,6 +212,8 @@ def detect_model_type(clip=None, model=None, model_type_hint: Optional[str] = No
 
     cond_stage_model = getattr(clip, "cond_stage_model", None)
     cond_stage_name = cond_stage_model.__class__.__name__.lower() if cond_stage_model is not None else ""
+    if "krea2" in cond_stage_name or "krea" in cond_stage_name:
+        return "krea2"
     if "nextdit" in cond_stage_name or "zimage" in cond_stage_name or "lumina" in cond_stage_name:
         return "z_image"
     if "flux2" in cond_stage_name:
@@ -196,9 +229,18 @@ def detect_model_type(clip=None, model=None, model_type_hint: Optional[str] = No
     clip_key = getattr(tokenizer, "clip", None)
     clip_key_lower = clip_key.lower() if isinstance(clip_key, str) else ""
 
+    # Qwen3-VL (attribute name "qwen3vl_4b") is Krea2-specific in this ecosystem
+    # so far - check before the generic qwen3 fallback below.
+    tokenizer_attr_names = set(vars(tokenizer).keys())
+    if (
+        any("qwen3vl" in name.lower() for name in tokenizer_attr_names)
+        or "qwen3vl" in clip_name
+        or "qwen3vl" in clip_key_lower
+    ):
+        return "krea2"
+
     # Qwen3 tokenizer family can be used by both Z-Image and Flux2-Klein.
     # Without model context, treat it as generic qwen3.
-    tokenizer_attr_names = set(vars(tokenizer).keys())
     if (
         any("qwen3" in name.lower() for name in tokenizer_attr_names)
         or "qwen3" in clip_name
@@ -249,9 +291,12 @@ def _resolve_sd1_subtokenizer(tokenizer):
 
 def _resolve_qwen3_tokenizer(tokenizer):
     """
-    Resolve qwen3 tokenizer from multiple ComfyUI wrappers.
+    Resolve qwen3/qwen3-VL tokenizer from multiple ComfyUI wrappers.
+
+    "qwen3vl_4b" is Krea2's key (see comfy/text_encoders/krea2.py: Krea2TEModel
+    passes name="qwen3vl_4b" to SD1ClipModel), distinct from Z-Image's "qwen3_4b".
     """
-    for key in ("qwen3_4b", "qwen3_8b"):
+    for key in ("qwen3_4b", "qwen3_8b", "qwen3vl_4b"):
         if hasattr(tokenizer, key):
             resolved = _extract_nested_tokenizer(getattr(tokenizer, key))
             if resolved is not None:
@@ -259,7 +304,7 @@ def _resolve_qwen3_tokenizer(tokenizer):
 
     clip_name = str(getattr(tokenizer, "clip_name", "")).lower()
     clip_key = getattr(tokenizer, "clip", None)
-    if "qwen3" in clip_name and hasattr(tokenizer, clip_name):
+    if ("qwen3" in clip_name or "qwen3vl" in clip_name) and hasattr(tokenizer, clip_name):
         resolved = _extract_nested_tokenizer(getattr(tokenizer, clip_name))
         if resolved is not None:
             return resolved
@@ -291,7 +336,7 @@ def get_tokenizer_for_model(clip, model_type: str = None):
     if tokenizer is None:
         raise ValueError("Could not find clip.tokenizer on CLIP object.")
 
-    if model_type in ("z_image", "flux2", "qwen3"):
+    if model_type in ("z_image", "flux2", "qwen3", "krea2"):
         resolved = _resolve_qwen3_tokenizer(tokenizer)
         if resolved is not None:
             return resolved
@@ -783,6 +828,135 @@ def find_concept_positions_qwen3(
     return concept_pos_map
 
 
+def _find_krea2_template_end(token_ids: List[int]) -> int:
+    """
+    Replicate Krea2TEModel.encode_token_weights's prefix-stripping logic (see
+    comfy/text_encoders/krea2.py) so token positions line up with the
+    *stripped* embedding sequence actually fed into the DiT.
+
+    Krea2 finds the second "<|im_start|>" token (the one opening the "user"
+    turn), then additionally skips the following "user" + "\\n" tokens if
+    present, and drops everything before that point.
+    """
+    template_end = -1
+    count_im_start = 0
+    for i, tid in enumerate(token_ids):
+        if tid == KREA2_IM_START_ID and count_im_start < 2:
+            template_end = i
+            count_im_start += 1
+
+    if template_end == -1:
+        return 0
+
+    if len(token_ids) > template_end + 3:
+        if token_ids[template_end + 1] == KREA2_USER_TOKEN_ID:
+            if token_ids[template_end + 2] == KREA2_NEWLINE_TOKEN_ID:
+                template_end += 3
+
+    return template_end
+
+
+def find_concept_positions_krea2(
+    clip,
+    tokenizer,
+    prompts: Union[str, List[str]],
+    concepts: Dict[str, str],
+    filter_meaningless: bool = True,
+    filter_single_char: bool = True,
+) -> Dict[str, List[List[int]]]:
+    """
+    Find token positions for Krea 2 (Qwen3-VL-4B, 12-layer tap).
+
+    Krea2's own text encoder (comfy/text_encoders/krea2.py :: Krea2TEModel)
+    wraps the prompt in KREA2_TEMPLATE (a fixed, non-configurable system
+    message) and then STRIPS everything up to and including the
+    "<|im_start|>user\\n" prefix before the conditioning tensor is built.
+    We replicate both steps and tokenize/search only within the stripped
+    range, so returned positions align directly with the actual
+    (B, seq_after_strip, 12*2560) conditioning tensor - no separate offset
+    subtraction needed downstream.
+    """
+    if isinstance(prompts, str):
+        prompts = [prompts]
+
+    prompt_data_list = []
+    for prompt in prompts:
+        wrapped_text = KREA2_TEMPLATE.format(prompt)
+
+        try:
+            token_weight_pairs = clip.tokenize(wrapped_text)
+            token_ids = _flatten_chunked_token_ids(token_weight_pairs)
+            if not token_ids:
+                raise ValueError("clip.tokenize returned no token ids")
+        except Exception as e:
+            print(f"[FreeFuse] Warning: clip.tokenize failed for Krea2, using direct tokenization: {e}")
+            encoded = tokenizer(wrapped_text, add_special_tokens=True)
+            token_ids = encoded['input_ids'] if hasattr(encoded, 'keys') else encoded.input_ids
+            if hasattr(token_ids, 'tolist'):
+                token_ids = token_ids.tolist()
+
+        template_end = _find_krea2_template_end(token_ids)
+        stripped_ids = token_ids[template_end:]
+        token_texts = [tokenizer.decode([tid]) for tid in stripped_ids]
+
+        concat_text = ""
+        token_spans = []
+        for tt in token_texts:
+            start = len(concat_text)
+            concat_text += tt
+            token_spans.append((start, len(concat_text)))
+
+        prompt_data_list.append({
+            "raw": prompt,
+            "template_end": template_end,
+            "active_token_texts": token_texts,
+            "concat_text": concat_text,
+            "token_spans": token_spans,
+        })
+
+    concept_pos_map = {}
+    for concept_name, concept_text in concepts.items():
+        concept_pos_map[concept_name] = []
+
+        for pd in prompt_data_list:
+            positions = []
+            positions_with_text = []
+
+            search_start = 0
+            while True:
+                idx = pd["concat_text"].find(concept_text, search_start)
+                if idx == -1:
+                    break
+                c_start, c_end = idx, idx + len(concept_text)
+
+                for tok_i, (ts, te) in enumerate(pd["token_spans"]):
+                    if te > c_start and ts < c_end and tok_i not in positions:
+                        positions.append(tok_i)
+                        positions_with_text.append((tok_i, pd["active_token_texts"][tok_i]))
+                search_start = idx + 1
+
+            if filter_meaningless and positions_with_text:
+                filtered_positions = [
+                    pos for pos, text in positions_with_text
+                    if not is_meaningless_token(text, check_single_char=filter_single_char)
+                ]
+                if not filtered_positions:
+                    non_punct = [
+                        pos for pos, text in positions_with_text
+                        if clean_token_text(text) not in PUNCTUATION
+                    ]
+                    if non_punct:
+                        filtered_positions = non_punct[:1]
+                    elif positions_with_text:
+                        filtered_positions = [positions_with_text[0][0]]
+                positions = filtered_positions
+
+            positions.sort()
+            concept_pos_map[concept_name].append(positions)
+
+    return concept_pos_map
+
+
 def find_concept_positions(
     clip,
     prompts: Union[str, List[str]],
@@ -828,8 +1002,14 @@ def find_concept_positions(
         model_type = _normalize_model_type(model_type) or model_type
     
     tokenizer = get_tokenizer_for_model(clip, model_type)
-    
-    if model_type in ('z_image', 'flux2', 'qwen3'):
+
+    if model_type == 'krea2':
+        return find_concept_positions_krea2(
+            clip, tokenizer, prompts, concepts,
+            filter_meaningless=filter_meaningless,
+            filter_single_char=filter_single_char,
+        )
+    elif model_type in ('z_image', 'flux2', 'qwen3'):
         qwen_template = KLEIN_NO_THINK_TEMPLATE if model_type == "flux2" else None
         return find_concept_positions_qwen3(
             clip, tokenizer, prompts, concepts,
@@ -853,7 +1033,7 @@ def find_concept_positions(
     else:
         raise ValueError(
             f"Unsupported model type: {model_type}. "
-            "Use 'flux', 'flux2', 'sdxl', 'z_image', 'qwen3', or 'sd1'."
+            "Use 'flux', 'flux2', 'sdxl', 'z_image', 'qwen3', 'krea2', or 'sd1'."
         )
 
 

--- a/nodes/attention_bias.py
+++ b/nodes/attention_bias.py
@@ -83,8 +83,9 @@ class FreeFuseAttentionBias:
                               "- double_stream_only: Only double-stream blocks (Flux/Flux2)\n"
                               "- single_stream_only: Only single-stream blocks (Flux/Flux2)\n"
                               "- last_half_double: Last half of double blocks\n"
-                              "- last_half: Last half of layers (Z-Image)\n"
-                              "- none: Disable attention bias"
+                              "- last_half: Last half of layers (Z-Image/Krea2)\n"
+                              "- none: Disable attention bias\n"
+                              "Note: Krea2 is single-stream, so double/single_stream_only fall back to 'last_half'."
                 }),
             }
         }
@@ -230,6 +231,30 @@ Parameters:
                 lora_masks=lora_masks_flat,
                 token_pos_maps=token_pos_maps,
             )
+        elif model_type == "krea2":
+            from ..freefuse_core.krea2_support import apply_krea2_bias_patches
+
+            lora_masks_flat = {}
+            for name, mask in mask_dict.items():
+                if name.startswith("_"):
+                    continue
+                if mask.dim() == 3:
+                    mask = mask[0]
+                mask_flat = mask.reshape(-1)
+                lora_masks_flat[name] = mask_flat.unsqueeze(0)
+
+            krea2_block_indices = self._resolve_krea2_bias_blocks(model_clone, bias_blocks)
+
+            # Note: unlike Flux/Z-Image, this installs via model_options["model_function_wrapper"]
+            # (hooks are installed/removed on every single forward call) rather than persistent
+            # hooks - see krea2_support.apply_krea2_bias_patches for why.
+            apply_krea2_bias_patches(
+                model_clone,
+                lora_masks=lora_masks_flat,
+                token_pos_maps=token_pos_maps,
+                config=config,
+                block_indices=krea2_block_indices,
+            )
         else:  # SDXL
             # SDXL uses per-layer bias computation
             apply_attention_bias_patches(
@@ -285,6 +310,29 @@ Parameters:
                 max_pos = max(positions_list[0])
                 txt_seq_len = max(txt_seq_len, max_pos + 10)
         return txt_seq_len
+
+    def _resolve_krea2_bias_blocks(self, model_clone, bias_blocks: str) -> List[int]:
+        """
+        Map the (Flux-oriented) bias_blocks dropdown to concrete Krea2 block
+        indices. Krea2 is single-stream (comfy.ldm.krea2.model.SingleStreamDiT),
+        so there is no double/single-stream distinction - those options fall
+        back to a sensible default.
+        """
+        diffusion_model = model_clone.model.diffusion_model
+        blocks = getattr(diffusion_model, "blocks", None)
+        n = len(blocks) if blocks is not None else 28
+
+        if bias_blocks == "all":
+            return list(range(n))
+        if bias_blocks in ("last_half", "last_half_double"):
+            return list(range(n // 2, n))
+        if bias_blocks in ("double_stream_only", "single_stream_only"):
+            print(
+                f"[FreeFuse] Note: '{bias_blocks}' is Flux-specific and doesn't apply to "
+                f"Krea2 (single-stream architecture) - using 'last_half' instead."
+            )
+            return list(range(n // 2, n))
+        return list(range(n // 2, n))
 
 
 class FreeFuseAttentionBiasVisualize:

--- a/nodes/mask_applicator.py
+++ b/nodes/mask_applicator.py
@@ -308,7 +308,38 @@ When enabled, constructs soft attention bias to guide cross-attention:
             print(f"[FreeFuse] Applied attention bias for Z-Image "
                   f"(bias_scale={bias_scale}, positive_scale={positive_bias_scale}, "
                   f"bidirectional={bidirectional}, img_seq={img_seq_len}, cap_seq={cap_seq_len})")
-        
+
+        elif model_type == "krea2":
+            # Krea2 is single-stream, [txt, img] sequence (text FIRST, same as Z-Image's
+            # captioning convention but opposite token order - see krea2_support.py).
+            # Uses model_options["model_function_wrapper"] internally, NOT the
+            # replace-patch dispatcher used by flux/flux2/z_image/sdxl above, because
+            # Krea2 has no per-clone patch hook in its forward loop (see krea2_support.py
+            # docstring for why raw hooks would otherwise leak into unrelated generations).
+            from ..freefuse_core.krea2_support import apply_krea2_bias_patches
+
+            lora_masks_flat = {}
+            for name, mask in mask_dict.items():
+                if name.startswith("_"):
+                    continue
+                if mask.dim() == 3:
+                    mask = mask[0]
+                mask_flat = mask.reshape(-1)
+                lora_masks_flat[name] = mask_flat.unsqueeze(0)
+
+            krea2_block_indices = self._resolve_krea2_bias_blocks(model_patcher, bias_blocks)
+
+            apply_krea2_bias_patches(
+                model_patcher,
+                lora_masks=lora_masks_flat,
+                token_pos_maps=token_pos_maps,
+                config=config,
+                block_indices=krea2_block_indices,
+            )
+            print(f"[FreeFuse] Applied attention bias for Krea2 "
+                  f"(bias_scale={bias_scale}, positive_scale={positive_bias_scale}, "
+                  f"blocks={bias_blocks} -> {krea2_block_indices})")
+
         else:  # SDXL
             # For SDXL, use the direct SDXL bias patches
             apply_attention_bias_patches(
@@ -324,13 +355,37 @@ When enabled, constructs soft attention bias to guide cross-attention:
             print(f"[FreeFuse] Applied attention bias for SDXL "
                   f"(bias_scale={bias_scale}, positive_scale={positive_bias_scale})")
     
+    def _resolve_krea2_bias_blocks(self, model_patcher, bias_blocks: str) -> List[int]:
+        """
+        Map the (Flux-oriented) bias_blocks dropdown to concrete Krea2 block
+        indices. Krea2 is single-stream (comfy.ldm.krea2.model.SingleStreamDiT),
+        so there is no double/single-stream distinction - those options fall
+        back to a sensible default. Kept identical to nodes/attention_bias.py's
+        version so both entry points behave the same way.
+        """
+        diffusion_model = self._get_diffusion_model(model_patcher)
+        blocks = getattr(diffusion_model, "blocks", None)
+        n = len(blocks) if blocks is not None else 28
+
+        if bias_blocks == "all":
+            return list(range(n))
+        if bias_blocks in ("last_half", "last_half_double"):
+            return list(range(n // 2, n))
+        if bias_blocks in ("double_stream_only", "single_stream_only"):
+            print(
+                f"[FreeFuse] Note: '{bias_blocks}' is Flux-specific and doesn't apply to "
+                f"Krea2 (single-stream architecture) - using 'last_half' instead."
+            )
+            return list(range(n // 2, n))
+        return list(range(n // 2, n))
+
     def _get_latent_size(
         self,
         mask_dict: Dict[str, torch.Tensor],
         latent: Optional[Dict],
     ) -> Optional[Tuple[int, int]]:
         """Determine latent size from masks or latent input.
-        
+
         IMPORTANT: For Flux models, the masks are in packed space (H/16 x W/16),
         not the original latent space (H/8 x W/8). We should prioritize the mask
         dimensions as they represent the actual spatial resolution of the masks.

--- a/nodes/sampler.py
+++ b/nodes/sampler.py
@@ -23,6 +23,7 @@ from ..freefuse_core.attention_replace import (
     compute_flux_similarity_maps_from_outputs,
     compute_z_image_similarity_maps,
 )
+from ..freefuse_core.krea2_support import apply_krea2_replace_patches
 from ..freefuse_core.mask_utils import generate_masks
 from ..freefuse_core.tensor_debug import format_tensor_stats, tensor_scalar_to_float
 from ..freefuse_core.token_utils import detect_model_type
@@ -81,11 +82,11 @@ class FreeFusePhase1Sampler:
                 # Block selection — Flux
                 "collect_block": ("INT", {
                     "default": 18, "min": 0, "max": 56,
-                    "tooltip": "[Flux/Flux2/Z-Image only] Flux uses transformer_blocks.<idx>; Flux2 uses single_transformer_blocks.<idx>; Z-Image uses layers.<idx>. Ignored for SDXL."
+                    "tooltip": "[Flux/Flux2/Z-Image/Krea2 only] Flux uses transformer_blocks.<idx>; Flux2 uses single_transformer_blocks.<idx>; Z-Image uses layers.<idx>; Krea2 uses blocks.<idx> (0-27). Ignored for SDXL."
                 }),
                 "collect_block_end": ("INT", {
                     "default": 18, "min": 0, "max": 56,
-                    "tooltip": "[Flux/Flux2/Z-Image only] Optional end block (inclusive). If > collect_block, collect a range and aggregate by majority voting."
+                    "tooltip": "[Flux/Flux2/Z-Image/Krea2 only] Optional end block (inclusive). If > collect_block, collect a range and aggregate by majority voting."
                 }),
                 # Block selection — SDXL
                 "collect_region": (list(SDXL_COLLECT_REGION_MAP.keys()), {
@@ -275,6 +276,8 @@ for Phase 2 generation with the same seed and steps."""
                 auto_temperature = 4000.0   # matches reference FreeFuseZImageAttnProcessor
             elif patch_model_type in ("flux", "flux2"):
                 auto_temperature = 4000.0
+            elif patch_model_type == "krea2":
+                auto_temperature = 4000.0   # single-stream, RoPE+QK-norm attn like Z-Image; tune later
             else:
                 auto_temperature = 300.0
         else:
@@ -304,7 +307,7 @@ for Phase 2 generation with the same seed and steps."""
             sdxl_collect_blocks = [(block_name, block_num, tf_idx)]
             print(f"[FreeFuse] SDXL collect block: ({block_name}, {block_num}, {tf_idx}) "
                   f"from region='{collect_region}'")
-        elif patch_model_type in ("flux", "flux2", "z_image"):
+        elif patch_model_type in ("flux", "flux2", "z_image", "krea2"):
             range_start = int(collect_block)
             range_end = int(collect_block_end)
             if range_end < range_start:
@@ -321,8 +324,9 @@ for Phase 2 generation with the same seed and steps."""
                     flux_collect_blocks = range_collect_blocks
                 elif patch_model_type == "flux2":
                     flux2_collect_blocks = range_collect_blocks
-                else:
+                elif patch_model_type == "z_image":
                     z_image_collect_blocks = range_collect_blocks
+                # krea2 uses range_collect_blocks directly (see apply_krea2_replace_patches call below)
                 print(
                     f"[FreeFuse] {patch_model_type} range mode: collecting blocks {range_start}-{range_end} "
                     f"({len(range_collect_blocks)} blocks)"
@@ -334,14 +338,21 @@ for Phase 2 generation with the same seed and steps."""
                 f"using collect_block={collect_block}."
             )
             
-        apply_freefuse_replace_patches(
-            model_clone, freefuse_state, 
-            model_type=patch_model_type,
-            sdxl_collect_blocks=sdxl_collect_blocks,
-            flux_collect_blocks=flux_collect_blocks,
-            flux2_collect_blocks=flux2_collect_blocks,
-            z_image_collect_blocks=z_image_collect_blocks,
-        )
+        krea2_replacer = None
+        if patch_model_type == "krea2":
+            krea2_replacer = apply_krea2_replace_patches(
+                model_clone, freefuse_state,
+                krea2_collect_blocks=range_collect_blocks,  # None -> falls back to [state.collect_block]
+            )
+        else:
+            apply_freefuse_replace_patches(
+                model_clone, freefuse_state,
+                model_type=patch_model_type,
+                sdxl_collect_blocks=sdxl_collect_blocks,
+                flux_collect_blocks=flux_collect_blocks,
+                flux2_collect_blocks=flux2_collect_blocks,
+                z_image_collect_blocks=z_image_collect_blocks,
+            )
         
         # Get latent info
         latent_image = latent["samples"]
@@ -391,7 +402,15 @@ for Phase 2 generation with the same seed and steps."""
                         else f"layer {collect_block}"
                     )
                     if patch_model_type == "z_image"
-                    else f"{collect_region} tf={collect_tf_index}"
+                    else (
+                        (
+                            f"blocks.{collect_block}-{collect_block_end}"
+                            if (patch_model_type == "krea2" and range_collect_blocks is not None)
+                            else f"blocks.{collect_block}"
+                        )
+                        if patch_model_type == "krea2"
+                        else f"{collect_region} tf={collect_tf_index}"
+                    )
                 )
             )
         )
@@ -479,6 +498,13 @@ for Phase 2 generation with the same seed and steps."""
             empty_masks = {name: torch.ones(latent_h, latent_w) for name in concepts}
             preview = self._create_preview(empty_masks, img_w, img_h)
             return (model_clone, {"masks": empty_masks}, preview)
+        finally:
+            # Krea2 uses raw torch hooks (no ComfyUI patch-dict lifecycle), so they
+            # must be removed explicitly or they accumulate on the shared module
+            # across repeated Phase-1 runs.
+            if krea2_replacer is not None:
+                krea2_replacer.remove()
+                print("[FreeFuse Krea2] Removed Phase-1 collection hooks")
         
         # Get similarity maps directly from freefuse_state
         similarity_maps = freefuse_state.similarity_maps

--- a/workflows/krea2_freefuse_with_editor.json
+++ b/workflows/krea2_freefuse_with_editor.json
@@ -1,0 +1,1838 @@
+{
+  "id": "4317fa4a-8c4e-44ce-87ac-86a4257b12ee",
+  "revision": 0,
+  "last_node_id": 110,
+  "last_link_id": 60,
+  "nodes": [
+    {
+      "id": 107,
+      "type": "PreviewImage",
+      "pos": [
+        3580.4643459059903,
+        157.26203419062068
+      ],
+      "size": [
+        140,
+        246
+      ],
+      "flags": {},
+      "order": 23,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 58
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 25,
+      "type": "PreviewImage",
+      "pos": [
+        2742.708884356489,
+        287.70422869851967
+      ],
+      "size": [
+        260,
+        246.00000000000003
+      ],
+      "flags": {},
+      "order": 20,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 40
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "title": "Combined Masks",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 26,
+      "type": "PreviewImage",
+      "pos": [
+        2755.7862574172154,
+        590.8837952800575
+      ],
+      "size": [
+        260,
+        246
+      ],
+      "flags": {},
+      "order": 21,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 41
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "title": "Individual Masks",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 15,
+      "type": "FreeFuseMaskPreview",
+      "pos": [
+        2302.710810122673,
+        518.3379626565584
+      ],
+      "size": [
+        320,
+        150
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "masks",
+          "type": "FREEFUSE_MASKS",
+          "link": 20
+        }
+      ],
+      "outputs": [
+        {
+          "name": "combined_preview",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            40
+          ]
+        },
+        {
+          "name": "individual_masks",
+          "type": "IMAGE",
+          "slot_index": 1,
+          "links": [
+            41
+          ]
+        }
+      ],
+      "title": "Detailed Mask Preview",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseMaskPreview"
+      },
+      "widgets_values": [
+        512,
+        512,
+        true,
+        true
+      ]
+    },
+    {
+      "id": 13,
+      "type": "PreviewImage",
+      "pos": [
+        2303.419295764101,
+        150.60704056635078
+      ],
+      "size": [
+        320,
+        280
+      ],
+      "flags": {},
+      "order": 19,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 21
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "title": "Phase 1 Mask Preview",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 105,
+      "type": "FreeFuseMaskReassemble",
+      "pos": [
+        3748.2118248662337,
+        285.21742133727423
+      ],
+      "size": [
+        250.03125,
+        102
+      ],
+      "flags": {},
+      "order": 22,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "original_mask_bank",
+          "type": "FREEFUSE_MASKS",
+          "link": 69
+        },
+        {
+          "name": "freefuse_data",
+          "shape": 7,
+          "type": "FREEFUSE_DATA",
+          "link": 70
+        },
+        {
+          "name": "slot_names",
+          "shape": 7,
+          "type": "STRING",
+          "widget": {
+            "name": "slot_names"
+          },
+          "link": 71
+        }
+      ],
+      "outputs": [
+        {
+          "name": "new_mask_bank",
+          "type": "FREEFUSE_MASKS",
+          "slot_index": 0,
+          "links": [
+            82
+          ]
+        }
+      ],
+      "title": "Mask Reassemble",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseMaskReassemble"
+      },
+      "widgets_values": [
+        true,
+        true
+      ]
+    },
+    {
+      "id": 21,
+      "type": "StringConcatenate",
+      "pos": [
+        1320,
+        323.8608675812715
+      ],
+      "size": [
+        340,
+        166
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "string_b",
+          "type": "STRING",
+          "widget": {
+            "name": "string_b"
+          },
+          "link": 36
+        }
+      ],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            37
+          ]
+        }
+      ],
+      "title": "Lumina2 Prompt Wrapper",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "StringConcatenate"
+      },
+      "widgets_values": [
+        "You are an assistant designed to generate superior images with the superior degree of image-text alignment based on textual prompts or user prompts. <Prompt Start> ",
+        "On the left side stands Durian, a soldier clad in combat gear with short brown hair. He clutches a deflated soccer ball at his chest like it's precious — fingers digging into the soft leather as silent sobs rack his frame. The worn sole of the ball peels slightly at the mud caked on its surface. He is very sad\nNext to him stands Kim Possible, a cartoon girl with red-blonde hair. She stands next to the soldier and smiles at him while gently placing her hand on his arm to comfort him.\nthey are standing outside in a photorealistic public park with green trees in the background",
+        ""
+      ]
+    },
+    {
+      "id": 8,
+      "type": "FreeFuseTokenPositions",
+      "pos": [
+        1317.4491991107732,
+        130.68223237844572
+      ],
+      "size": [
+        340,
+        156
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 62
+        },
+        {
+          "name": "freefuse_data",
+          "type": "FREEFUSE_DATA",
+          "link": 11
+        },
+        {
+          "name": "prompt",
+          "type": "STRING",
+          "widget": {
+            "name": "prompt"
+          },
+          "link": 35
+        }
+      ],
+      "outputs": [
+        {
+          "name": "freefuse_data",
+          "type": "FREEFUSE_DATA",
+          "slot_index": 0,
+          "links": [
+            14,
+            66,
+            68,
+            70
+          ]
+        }
+      ],
+      "title": "Compute Token Positions",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseTokenPositions"
+      },
+      "widgets_values": [
+        "On the left side stands Durian, a soldier clad in combat gear with short brown hair. He clutches a deflated soccer ball at his chest like it's precious — fingers digging into the soft leather as silent sobs rack his frame. The worn sole of the ball peels slightly at the mud caked on its surface. He is very sad\nNext to him stands Kim Possible, a cartoon girl with red-blonde hair. She stands next to the soldier and smiles at him while gently placing her hand on his arm to comfort him.\nthey are standing outside in a photorealistic public park with green trees in the background",
+        true,
+        true
+      ]
+    },
+    {
+      "id": 7,
+      "type": "ModelSamplingAuraFlow",
+      "pos": [
+        454.50082485968056,
+        679.8348510244531
+      ],
+      "size": [
+        315,
+        60
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 61
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            51
+          ]
+        }
+      ],
+      "title": "Model Sampling Patch (AuraFlow)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "ModelSamplingAuraFlow"
+      },
+      "widgets_values": [
+        3
+      ]
+    },
+    {
+      "id": 10,
+      "type": "EmptySD3LatentImage",
+      "pos": [
+        1330.2032035569084,
+        857.8617632242674
+      ],
+      "size": [
+        340,
+        106
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            17,
+            22,
+            50
+          ]
+        }
+      ],
+      "title": "Latent Image Size",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "EmptySD3LatentImage"
+      },
+      "widgets_values": [
+        1024,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 3,
+      "type": "VAELoader",
+      "pos": [
+        50,
+        450
+      ],
+      "size": [
+        315,
+        58
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            30
+          ]
+        }
+      ],
+      "title": "Load Z-Image VAE",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "ae.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors",
+            "directory": "vae"
+          }
+        ]
+      },
+      "widgets_values": [
+        "krea2RealVae_v10.safetensors"
+      ]
+    },
+    {
+      "id": 100,
+      "type": "Note",
+      "pos": [
+        -700,
+        50
+      ],
+      "size": [
+        700,
+        1100
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Z-Image Model Guide",
+      "properties": {
+        "text": ""
+      },
+      "widgets_values": [
+        "# FreeFuse Z-Image-Turbo - Model & LoRA Guide\n# FreeFuse Z-Image-Turbo - 模型与LoRA指南\n\n═══════════════════════════════════════\n\n## Required Models / 所需模型\n\n### text_encoders/\n- qwen_3_4b.safetensors\n  https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors\n\n### diffusion_models/\n- z_image_turbo_bf16.safetensors\n  https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors\n\n### vae/\n- ae.safetensors\n  https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors\n\n### loras/\n- Jinx_Arcane_zit.safetensors\n  https://huggingface.co/lsmpp/freefuse_example_loras/resolve/main/Jinx_Arcane_zit.safetensors?download=true\n- skeletor_zit.safetensors\n  https://huggingface.co/lsmpp/freefuse_example_loras/resolve/main/skeletor_zit.safetensors?download=true\n\nPlace these under ComfyUI/models/loras/.\n将以上LoRA放在 ComfyUI/models/loras/ 目录。\n\n═══════════════════════════════════════\n\n## Important Notes / 重要提示\n- This workflow uses two-phase FreeFuse (mask collect -> masked generation).\n- 本工作流使用两阶段FreeFuse（掩码收集 -> 掩码生成）。\n- Z-Image uses 16-channel latent, so this workflow uses EmptySD3LatentImage.\n- Z-Image 使用16通道latent，因此使用 EmptySD3LatentImage。\n- Keep Phase1 and Phase2 steps/sampler/scheduler consistent.\n- 阶段1与阶段2的步数、采样器和调度器应保持一致。\n\nAdvanced LoRA slots:\n- LoRA 1/2 are active defaults.\n- LoRA 3/4 are optional slots (default strength=0, safe to keep connected).\n- To enable LoRA 3/4, set strength_model/strength_clip > 0 and add matching concept_text in Concept Mapping."
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 101,
+      "type": "Note",
+      "pos": [
+        -694.8444062850768,
+        1195.91015625
+      ],
+      "size": [
+        700,
+        2200
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Z-Image Parameters",
+      "properties": {
+        "text": ""
+      },
+      "widgets_values": [
+        "# FreeFuse Z-Image-Turbo - Advanced Workflow\n# FreeFuse Z-Image-Turbo - 高级工作流\n\nAdvanced features included:\n- 4 LoRA slots in chain (LoRA 3/4 default strength=0, optional)\n- Two-phase FreeFuse with stronger default cleanup\n- Full Z-Image prompt alignment (Lumina2 wrapper + token position alignment)\n- New sampler parameter support: collect_block_end (kept equal to collect_block for Z-Image)\n\nRecommended defaults:\n- seed: 77\n- steps: 12\n- collect_step: 3\n- cfg: 1.0\n- sampler/scheduler: euler + simple\n- collect_block / collect_block_end: 18 / 18\n- temperature: 0 (auto)\n- top_k_ratio: 0.1\n- disable_lora_phase1: true\n- use_morphological_cleaning: true\n\nMask applicator:\n- enable_token_masking: true\n- enable_attention_bias: true\n- bias_scale: 4.0\n- positive_bias_scale: 2.0\n- bidirectional: true\n- use_positive_bias: true\n- bias_blocks: all\n\nHow to enable LoRA 3/4:\n1. Set LoRA 3/4 strength_model/strength_clip > 0\n2. Fill matching adapter_name_3/4 + concept_text_3/4 in Concept Mapping\n3. Make sure concept_text appears verbatim in main prompt"
+      ],
+      "color": "#224",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 11,
+      "type": "CLIPTextEncode",
+      "pos": [
+        1330.7282975899554,
+        709.6439356711693
+      ],
+      "size": [
+        340,
+        100
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 64
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            38,
+            39
+          ]
+        }
+      ],
+      "title": "Negative Conditioning",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "You are an assistant designed to generate superior images with the superior degree of image-text alignment based on textual prompts or user prompts. <Prompt Start> "
+      ]
+    },
+    {
+      "id": 4,
+      "type": "FreeFuseLoRALoader",
+      "pos": [
+        459.3150268373952,
+        184.67128771837312
+      ],
+      "size": [
+        315,
+        170
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 59
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 60
+        },
+        {
+          "name": "freefuse_data",
+          "shape": 7,
+          "type": "FREEFUSE_DATA",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            52,
+            55
+          ]
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": [
+            53,
+            56
+          ]
+        },
+        {
+          "name": "freefuse_data",
+          "type": "FREEFUSE_DATA",
+          "slot_index": 2,
+          "links": [
+            54,
+            57
+          ]
+        }
+      ],
+      "title": "LoRA 1: Jinx",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseLoRALoader"
+      },
+      "widgets_values": [
+        "Krea2\\DurianK2.safetensors",
+        "Durian",
+        0.8,
+        0.8
+      ]
+    },
+    {
+      "id": 103,
+      "type": "FreeFuseLoRALoader",
+      "pos": [
+        437.83557330065366,
+        458.51469994635823
+      ],
+      "size": [
+        315,
+        170
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 55
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 56
+        },
+        {
+          "name": "freefuse_data",
+          "shape": 7,
+          "type": "FREEFUSE_DATA",
+          "link": 57
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            61
+          ]
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "slot_index": 1,
+          "links": [
+            62,
+            63,
+            64
+          ]
+        },
+        {
+          "name": "freefuse_data",
+          "type": "FREEFUSE_DATA",
+          "slot_index": 2,
+          "links": [
+            65
+          ]
+        }
+      ],
+      "title": "LoRA 4 (Optional): Prop/Detail",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseLoRALoader"
+      },
+      "widgets_values": [
+        "Krea2\\Krea 2 - Kim Possible.safetensors",
+        "kimpossible",
+        0.8,
+        0.8
+      ]
+    },
+    {
+      "id": 9,
+      "type": "CLIPTextEncode",
+      "pos": [
+        1324.4334239940108,
+        535.6120651297018
+      ],
+      "size": [
+        340,
+        120
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 63
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 37
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            16,
+            28
+          ]
+        }
+      ],
+      "title": "Positive Conditioning",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "You are an assistant designed to generate superior images with the superior degree of image-text alignment based on textual prompts or user prompts. <Prompt Start> A picture of two characters, a starry night scene with northern lights in background: The first character is Jinx_Arcane, a young woman with long blue hair in a loose braid and bright blue eyes, wearing a cropped halter top, gloves, striped pants with belts, and visible tattoos and the second character is Skeletor in purple hooded cloak flexing muscular blue arms triumphantly, skull face grinning menacingly, cartoon animation style, Masters of the Universe character, vibrant purple and blue color scheme"
+      ]
+    },
+    {
+      "id": 109,
+      "type": "CLIPLoader",
+      "pos": [
+        54.745698145576604,
+        294.82972452555015
+      ],
+      "size": [
+        314.7803195240541,
+        106
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            60
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.76",
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "Huihui-Qwen3-VL-4B-Instruct-abliterated.safetensors",
+        "krea2",
+        "default"
+      ],
+      "color": "#f66744",
+      "bgcolor": "#2a2a2a"
+    },
+    {
+      "id": 108,
+      "type": "UNETLoader",
+      "pos": [
+        59.84729992403102,
+        135.09647069316546
+      ],
+      "size": [
+        307.1279168563725,
+        107.5080088922723
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            59
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.76",
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "krea2_turbo_fp8_scaled.safetensors",
+        "default"
+      ],
+      "color": "#f66744",
+      "bgcolor": "#2a2a2a"
+    },
+    {
+      "id": 14,
+      "type": "FreeFuseMaskApplicator",
+      "pos": [
+        4070.3341374692195,
+        138.93045102340253
+      ],
+      "size": [
+        380,
+        320
+      ],
+      "flags": {},
+      "order": 24,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 18
+        },
+        {
+          "name": "masks",
+          "type": "FREEFUSE_MASKS",
+          "link": 82
+        },
+        {
+          "name": "freefuse_data",
+          "type": "FREEFUSE_DATA",
+          "link": 66
+        },
+        {
+          "name": "latent",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 22
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            23
+          ]
+        }
+      ],
+      "title": "Phase 2: Apply Masks",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseMaskApplicator"
+      },
+      "widgets_values": [
+        true,
+        true,
+        4,
+        2,
+        true,
+        true,
+        "all"
+      ]
+    },
+    {
+      "id": 104,
+      "type": "FreeFuseMaskTap",
+      "pos": [
+        3186.2065705010255,
+        150.0226984970621
+      ],
+      "size": [
+        252.853125,
+        358
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "mask_bank",
+          "type": "FREEFUSE_MASKS",
+          "link": 67
+        },
+        {
+          "name": "freefuse_data",
+          "shape": 7,
+          "type": "FREEFUSE_DATA",
+          "link": 68
+        }
+      ],
+      "outputs": [
+        {
+          "name": "mask_bank",
+          "type": "FREEFUSE_MASKS",
+          "slot_index": 0,
+          "links": [
+            69
+          ]
+        },
+        {
+          "name": "slot_names",
+          "type": "STRING",
+          "slot_index": 1,
+          "links": [
+            71
+          ]
+        },
+        {
+          "name": "slot_mask_images",
+          "type": "IMAGE",
+          "slot_index": 2,
+          "links": [
+            58
+          ]
+        }
+      ],
+      "title": "Mask Tap (Optional Edit Branch)",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseMaskTap",
+        "image": "clipspace/clipspace-painted-masked-1772432002692.png [input]"
+      },
+      "widgets_values": [
+        "",
+        "",
+        "",
+        "freefuse-masktap-slot-a19071cc38ae-03.png [temp]",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "clipspace/freefuse-masktap-edit-s8-1783201313832.png [input]",
+        "2",
+        "Open Mask Editor",
+        "Clear Current Slot"
+      ]
+    },
+    {
+      "id": 106,
+      "type": "Note",
+      "pos": [
+        3149.3785771401513,
+        628.667856564577
+      ],
+      "size": [
+        640,
+        260
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [],
+      "title": "Mask Edit (Optional)",
+      "properties": {
+        "text": ""
+      },
+      "widgets_values": [
+        "# Optional: Interactive Mask Editing\n1) Phase1 masks -> Mask Tap\n2) In Mask Tap, choose `Edit Slot` then click `Open Mask Editor`\n3) Draw/erase directly on the current LoRA mask, then close editor\n4) Reassemble -> Mask Applicator\n\nDefault behavior remains pass-through when no slot is edited."
+      ],
+      "color": "#224",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 17,
+      "type": "VAEDecode",
+      "pos": [
+        4589.7083717355545,
+        118.56527729634017
+      ],
+      "size": [
+        200,
+        50
+      ],
+      "flags": {},
+      "order": 26,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 24
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 30
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            26
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 16,
+      "type": "KSampler",
+      "pos": [
+        4070.956593167392,
+        524.3628011857791
+      ],
+      "size": [
+        380,
+        350
+      ],
+      "flags": {},
+      "order": 25,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 23
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 28
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 39
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 50
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "slot_index": 0,
+          "links": [
+            24
+          ]
+        }
+      ],
+      "title": "Phase 2: Full Generation",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        354347915735006,
+        "fixed",
+        4,
+        1,
+        "er_sde",
+        "simple",
+        1
+      ]
+    },
+    {
+      "id": 6,
+      "type": "FreeFuseConceptMap",
+      "pos": [
+        855.4969904926002,
+        127.63961633280549
+      ],
+      "size": [
+        395.4323453798247,
+        491.9023196712286
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "freefuse_data",
+          "shape": 7,
+          "type": "FREEFUSE_DATA",
+          "link": 65
+        }
+      ],
+      "outputs": [
+        {
+          "name": "freefuse_data",
+          "type": "FREEFUSE_DATA",
+          "slot_index": 0,
+          "links": [
+            11
+          ]
+        }
+      ],
+      "title": "Concept Mapping",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFuseConceptMap"
+      },
+      "widgets_values": [
+        "Durian",
+        "On the left side stands Durian, a soldier clad in combat gear with short brown hair. He clutches a deflated soccer ball at his chest like it's precious — fingers digging into the soft leather as silent sobs rack his frame. The worn sole of the ball peels slightly at the mud caked on its surface. He is very sad",
+        "kimpossible",
+        "Next to him stands Kim Possible, a cartoon girl with red-blonde hair. She stands next to the soldier and smiles at him while gently placing her hand on his arm to comfort him.",
+        "",
+        "",
+        "",
+        "",
+        true,
+        "photorealistic public park with green trees in the background"
+      ]
+    },
+    {
+      "id": 20,
+      "type": "PrimitiveNode",
+      "pos": [
+        859.3076904446008,
+        667.3369191642371
+      ],
+      "size": [
+        381.27540044461375,
+        302.1790600228394
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "widget": {
+            "name": "prompt"
+          },
+          "slot_index": 0,
+          "links": [
+            35,
+            36
+          ]
+        }
+      ],
+      "title": "Main Prompt (User Prompt)",
+      "properties": {
+        "Run widget replace on values": false
+      },
+      "widgets_values": [
+        "On the left side stands Durian, a soldier clad in combat gear with short brown hair. He clutches a deflated soccer ball at his chest like it's precious — fingers digging into the soft leather as silent sobs rack his frame. The worn sole of the ball peels slightly at the mud caked on its surface. He is very sad\nNext to him stands Kim Possible, a cartoon girl with red-blonde hair. She stands next to the soldier and smiles at him while gently placing her hand on his arm to comfort him.\nthey are standing outside in a photorealistic public park with green trees in the background"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "FreeFusePhase1Sampler",
+      "pos": [
+        1805.9835749762706,
+        151.1500623712738
+      ],
+      "size": [
+        380,
+        710
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 51
+        },
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 16
+        },
+        {
+          "name": "neg_conditioning",
+          "type": "CONDITIONING",
+          "link": 38
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "link": 17
+        },
+        {
+          "name": "freefuse_data",
+          "type": "FREEFUSE_DATA",
+          "link": 14
+        },
+        {
+          "name": "sigmas",
+          "shape": 7,
+          "type": "SIGMAS",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            18
+          ]
+        },
+        {
+          "name": "masks",
+          "type": "FREEFUSE_MASKS",
+          "slot_index": 1,
+          "links": [
+            20,
+            67
+          ]
+        },
+        {
+          "name": "mask_preview",
+          "type": "IMAGE",
+          "slot_index": 2,
+          "links": [
+            21
+          ]
+        }
+      ],
+      "title": "Phase 1: Collect Masks",
+      "properties": {
+        "cnr_id": "freefuse",
+        "ver": "1.0.13",
+        "Node name for S&R": "FreeFusePhase1Sampler"
+      },
+      "widgets_values": [
+        8,
+        12,
+        12,
+        3,
+        1,
+        "euler",
+        "simple",
+        10,
+        10,
+        "output_early ★ (recommended)",
+        3,
+        0,
+        0.1,
+        true,
+        0.95,
+        true,
+        15,
+        0.01,
+        0.00004,
+        0.00004,
+        0.2,
+        0,
+        0,
+        1.3
+      ]
+    },
+    {
+      "id": 18,
+      "type": "SaveImage",
+      "pos": [
+        4603.859152393971,
+        242.9860009267584
+      ],
+      "size": [
+        639.9028236318209,
+        667.9616334133193
+      ],
+      "flags": {},
+      "order": 27,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 26
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "title": "Final Output",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.27.0",
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "FreeFuse/Krea2_output"
+      ]
+    }
+  ],
+  "links": [
+    [
+      11,
+      6,
+      0,
+      8,
+      1,
+      "FREEFUSE_DATA"
+    ],
+    [
+      14,
+      8,
+      0,
+      12,
+      4,
+      "FREEFUSE_DATA"
+    ],
+    [
+      16,
+      9,
+      0,
+      12,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      17,
+      10,
+      0,
+      12,
+      3,
+      "LATENT"
+    ],
+    [
+      18,
+      12,
+      0,
+      14,
+      0,
+      "MODEL"
+    ],
+    [
+      20,
+      12,
+      1,
+      15,
+      0,
+      "FREEFUSE_MASKS"
+    ],
+    [
+      21,
+      12,
+      2,
+      13,
+      0,
+      "IMAGE"
+    ],
+    [
+      22,
+      10,
+      0,
+      14,
+      3,
+      "LATENT"
+    ],
+    [
+      23,
+      14,
+      0,
+      16,
+      0,
+      "MODEL"
+    ],
+    [
+      24,
+      16,
+      0,
+      17,
+      0,
+      "LATENT"
+    ],
+    [
+      26,
+      17,
+      0,
+      18,
+      0,
+      "IMAGE"
+    ],
+    [
+      28,
+      9,
+      0,
+      16,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      30,
+      3,
+      0,
+      17,
+      1,
+      "VAE"
+    ],
+    [
+      35,
+      20,
+      0,
+      8,
+      2,
+      "STRING"
+    ],
+    [
+      36,
+      20,
+      0,
+      21,
+      0,
+      "STRING"
+    ],
+    [
+      37,
+      21,
+      0,
+      9,
+      1,
+      "STRING"
+    ],
+    [
+      38,
+      11,
+      0,
+      12,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      39,
+      11,
+      0,
+      16,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      40,
+      15,
+      0,
+      25,
+      0,
+      "IMAGE"
+    ],
+    [
+      41,
+      15,
+      1,
+      26,
+      0,
+      "IMAGE"
+    ],
+    [
+      50,
+      10,
+      0,
+      16,
+      3,
+      "LATENT"
+    ],
+    [
+      51,
+      7,
+      0,
+      12,
+      0,
+      "MODEL"
+    ],
+    [
+      61,
+      103,
+      0,
+      7,
+      0,
+      "MODEL"
+    ],
+    [
+      62,
+      103,
+      1,
+      8,
+      0,
+      "CLIP"
+    ],
+    [
+      63,
+      103,
+      1,
+      9,
+      0,
+      "CLIP"
+    ],
+    [
+      64,
+      103,
+      1,
+      11,
+      0,
+      "CLIP"
+    ],
+    [
+      65,
+      103,
+      2,
+      6,
+      0,
+      "FREEFUSE_DATA"
+    ],
+    [
+      66,
+      8,
+      0,
+      14,
+      2,
+      "FREEFUSE_DATA"
+    ],
+    [
+      67,
+      12,
+      1,
+      104,
+      0,
+      "FREEFUSE_MASKS"
+    ],
+    [
+      68,
+      8,
+      0,
+      104,
+      1,
+      "FREEFUSE_DATA"
+    ],
+    [
+      69,
+      104,
+      0,
+      105,
+      0,
+      "FREEFUSE_MASKS"
+    ],
+    [
+      70,
+      8,
+      0,
+      105,
+      1,
+      "FREEFUSE_DATA"
+    ],
+    [
+      71,
+      104,
+      1,
+      105,
+      2,
+      "STRING"
+    ],
+    [
+      82,
+      105,
+      0,
+      14,
+      1,
+      "FREEFUSE_MASKS"
+    ],
+    [
+      55,
+      4,
+      0,
+      103,
+      0,
+      "MODEL"
+    ],
+    [
+      56,
+      4,
+      1,
+      103,
+      1,
+      "CLIP"
+    ],
+    [
+      57,
+      4,
+      2,
+      103,
+      2,
+      "FREEFUSE_DATA"
+    ],
+    [
+      58,
+      104,
+      2,
+      107,
+      0,
+      "IMAGE"
+    ],
+    [
+      59,
+      108,
+      0,
+      4,
+      0,
+      "MODEL"
+    ],
+    [
+      60,
+      109,
+      0,
+      4,
+      1,
+      "CLIP"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "1. Load Models",
+      "bounding": [
+        30,
+        50,
+        380,
+        520
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 2,
+      "title": "2. Load LoRAs + Sampling Patch",
+      "bounding": [
+        430,
+        50,
+        384.6297036139474,
+        933.702963860526
+      ],
+      "color": "#2E8B57",
+      "flags": {}
+    },
+    {
+      "id": 3,
+      "title": "3. Concept Mapping",
+      "bounding": [
+        830,
+        50,
+        442.95720800304525,
+        935.0239098195655
+      ],
+      "color": "#88A825",
+      "flags": {}
+    },
+    {
+      "id": 4,
+      "title": "4. Conditioning (Lumina2)",
+      "bounding": [
+        1300,
+        50,
+        449.13100666920445,
+        919.4250555767032
+      ],
+      "color": "#DAA520",
+      "flags": {}
+    },
+    {
+      "id": 5,
+      "title": "5. Phase 1: Masks",
+      "bounding": [
+        1772.08821467225,
+        46.17379866615912,
+        454.95457732470504,
+        914.5051444994283
+      ],
+      "color": "#A8442A",
+      "flags": {}
+    },
+    {
+      "id": 6,
+      "title": "6. Phase 2: Generate",
+      "bounding": [
+        4032.095911111245,
+        57.625167382886424,
+        520,
+        850
+      ],
+      "color": "#7B3F9E",
+      "flags": {}
+    },
+    {
+      "id": 7,
+      "title": "mask_preview",
+      "bounding": [
+        2258.9082713077337,
+        52.23865043321675,
+        850,
+        820
+      ],
+      "color": "#40608a",
+      "flags": {}
+    },
+    {
+      "id": 8,
+      "title": "mask_editor(Optional)",
+      "bounding": [
+        3137.889952417249,
+        52.98341222323345,
+        871.7368575902888,
+        516.9147068986751
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    }
+  ],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.6807182552374176,
+      "offset": [
+        -3913.471102696847,
+        96.45023583597293
+      ]
+    },
+    "info": {
+      "name": "FreeFuse Z-Image-Turbo Advanced Workflow",
+      "description": "Advanced two-phase FreeFuse workflow for Z-Image-Turbo with 4 LoRA slots and collect_block_end-compatible sampler settings.",
+      "author": "FreeFuse Team",
+      "version": "2.0",
+      "notes": "Supports 4 chained LoRA slots (slot 3/4 optional), Lumina2 prompt alignment, and updated Phase1 sampler widgets including collect_block_end. Includes optional Mask Tap/Reassemble branch for manual mask editing.",
+      "models": {
+        "text_encoders": [
+          {
+            "name": "qwen_3_4b.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/text_encoders/qwen_3_4b.safetensors"
+          }
+        ],
+        "diffusion_models": [
+          {
+            "name": "z_image_turbo_bf16.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/diffusion_models/z_image_turbo_bf16.safetensors"
+          }
+        ],
+        "vae": [
+          {
+            "name": "ae.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/z_image_turbo/resolve/main/split_files/vae/ae.safetensors"
+          }
+        ],
+        "loras": [
+          {
+            "name": "Jinx_Arcane_zit.safetensors",
+            "note": "Z-Image LoRA for Jinx concept",
+            "url": "https://huggingface.co/lsmpp/freefuse_example_loras/resolve/main/Jinx_Arcane_zit.safetensors?download=true"
+          },
+          {
+            "name": "skeletor_zit.safetensors",
+            "note": "Z-Image LoRA for Skeletor concept",
+            "url": "https://huggingface.co/lsmpp/freefuse_example_loras/resolve/main/skeletor_zit.safetensors?download=true"
+          }
+        ]
+      }
+    },
+    "workflowRendererVersion": "LG",
+    "frontendVersion": "1.45.20",
+    "metadata": {
+      "name": "FreeFuse Z-Image-Turbo Advanced Workflow",
+      "description": "Advanced two-phase FreeFuse workflow for Z-Image-Turbo with 4 LoRA slots and collect_block_end-compatible sampler settings."
+    },
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Adds Krea2 support to the ComfyUI nodes, following the pattern from transfer_freefuse_to_more_arch_guide.md.

Krea2 (comfy/ldm/krea2/model.py, SingleStreamDiT) differs from Z-Image in a few ways this PR accounts for:
- No layers/replace-patch mechanism — Phase 1 uses plain torch hooks instead (see krea2_support.py docstring)
- Qwen3-VL-4B text encoder with a fixed system template and internal prefix-stripping (template_end) that token positions must match
- Phase 2 bias injection reuses the mask argument that Attention.forward/SingleStreamBlock.forward already thread through but never populate — avoids reimplementing RoPE/GQA
- Because Krea2 has no per-clone patch dict, Phase 2 hooks are scoped via model_options["model_function_wrapper"] so they can't leak into unrelated generations

New file: freefuse_core/krea2_support.py
Modified: freefuse_core/token_utils.py, nodes/sampler.py, nodes/attention_bias.py, nodes/mask_applicator.py

Tested manually on Windows/ComfyUI with the Z-Image-Turbo FreeFuse workflow adapted to Krea2 (two subject LoRAs + background), across a handful of generations.

Note on mask quality: results vary a lot with subject similarity. Visually distinct subjects (e.g. photoreal soldier + cartoon character) separate very cleanly. Visually similar subjects (e.g. two similar-looking real people) show more bleeding between masks - likely inherent to the attention-based routing approach rather than Krea2-specific, but I haven't cross-checked against Flux/Z-Image on similarly-similar subjects to confirm.

LoRAs used in the example images were sourced from Civitai (character LoRAs, 
not affiliated with this PR/repo - just for illustration).

Rough prototype — happy to iterate based on review feedback.



<img width="1024" height="1024" alt="Krea2_output_00001_" src="https://github.com/user-attachments/assets/c7ce0c13-51c8-4132-b6b5-edd4a85620dc" />
